### PR TITLE
Fixes issue with parametrizing URLs in OpenApiDocGeneratorPlugin

### DIFF
--- a/dev-proxy-plugins/RequestLogs/OpenApiDocGeneratorPlugin.cs
+++ b/dev-proxy-plugins/RequestLogs/OpenApiDocGeneratorPlugin.cs
@@ -351,7 +351,7 @@ public class OpenApiDocGeneratorPlugin : BaseProxyPlugin
       if (IsParametrizable(segment))
       {
         var parameterName = $"{previousSegment}-id";
-        segments[i] = "{" + parameterName + "}";
+        segments[i] = "{" + parameterName + "}/";
 
         pathItem.Parameters.Add(new OpenApiParameter
         {


### PR DESCRIPTION
Calling `curl -ix http://127.0.0.1:8000 https://jsonplaceholder.typicode.com/posts/1/comments` would result in a path like `"/posts/{posts-id}comments"` instead of `"/posts/{posts-id}/comments"`