### PR TITLE
Adds the CRUD API plugin. Closes #437

### DIFF
--- a/dev-proxy-plugins/MockResponses/CrudApiDefinitionLoader.cs
+++ b/dev-proxy-plugins/MockResponses/CrudApiDefinitionLoader.cs
@@ -1,0 +1,114 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.DevProxy.Abstractions;
+using System.Text.Json;
+
+namespace Microsoft.DevProxy.Plugins.MockResponses;
+
+internal class CrudApiDefinitionLoader : IDisposable
+{
+    private readonly ILogger _logger;
+    private readonly CrudApiConfiguration _configuration;
+
+    public CrudApiDefinitionLoader(ILogger logger, CrudApiConfiguration configuration)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+    }
+
+    private FileSystemWatcher? _watcher;
+
+    public void LoadApiDefinition()
+    {
+        if (!File.Exists(_configuration.ApiFile))
+        {
+            _logger.LogWarn($"File {_configuration.ApiFile} not found. CRUD API will be disabled");
+            return;
+        }
+
+        try
+        {
+            using (FileStream stream = new FileStream(_configuration.ApiFile, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
+            {
+                using (StreamReader reader = new StreamReader(stream))
+                {
+                    var apiDefinitionString = reader.ReadToEnd();
+                    var apiDefinitionConfig = JsonSerializer.Deserialize<CrudApiConfiguration>(apiDefinitionString);
+                    _configuration.BaseUrl = apiDefinitionConfig?.BaseUrl ?? string.Empty;
+                    _configuration.DataFile = apiDefinitionConfig?.DataFile ?? string.Empty;
+
+                    IEnumerable<CrudApiAction>? configResponses = apiDefinitionConfig?.Actions;
+                    if (configResponses is not null)
+                    {
+                        _configuration.Actions = configResponses;
+                        foreach (var action in _configuration.Actions)
+                        {
+                            if (string.IsNullOrEmpty(action.Method))
+                            {
+                                action.Method = action.Action switch
+                                {
+                                    CrudApiActionType.Create => "POST",
+                                    CrudApiActionType.GetAll => "GET",
+                                    CrudApiActionType.GetOne => "GET",
+                                    CrudApiActionType.Merge => "PATCH",
+                                    CrudApiActionType.Update => "PUT",
+                                    CrudApiActionType.Delete => "DELETE",
+                                    _ => throw new InvalidOperationException($"Unknown action type {action.Action}")
+                                };
+                            }
+                        }
+                        _logger.LogInfo($"{configResponses.Count()} actions for CRUD API loaded from {_configuration.ApiFile}");
+                    }
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError($"An error has occurred while reading {_configuration.ApiFile}:");
+            _logger.LogError(ex.Message);
+        }
+    }
+
+    public void InitApiDefinitionWatcher()
+    {
+        if (_watcher is not null)
+        {
+            return;
+        }
+
+        string path = Path.GetDirectoryName(_configuration.ApiFile) ?? throw new InvalidOperationException($"{_configuration.ApiFile} is an invalid path");
+        if (!File.Exists(_configuration.ApiFile))
+        {
+            _logger.LogWarn($"File {_configuration.ApiFile} not found. No CRUD API will be provided");
+            _configuration.Actions = Array.Empty<CrudApiAction>();
+            return;
+        }
+
+        _watcher = new FileSystemWatcher(Path.GetFullPath(path))
+        {
+            NotifyFilter = NotifyFilters.CreationTime
+                             | NotifyFilters.FileName
+                             | NotifyFilters.LastWrite
+                             | NotifyFilters.Size,
+            Filter = Path.GetFileName(_configuration.ApiFile),
+            EnableRaisingEvents = true
+        };
+        _watcher.Changed += ApiDefinitionFile_Changed;
+        _watcher.Created += ApiDefinitionFile_Changed;
+        _watcher.Deleted += ApiDefinitionFile_Changed;
+        _watcher.Renamed += ApiDefinitionFile_Changed;
+
+        LoadApiDefinition();
+    }
+
+    private void ApiDefinitionFile_Changed(object sender, FileSystemEventArgs e)
+    {
+        LoadApiDefinition();
+    }
+
+    public void Dispose()
+    {
+        _watcher?.Dispose();
+    }
+}

--- a/dev-proxy-plugins/MockResponses/CrudApiPlugin.cs
+++ b/dev-proxy-plugins/MockResponses/CrudApiPlugin.cs
@@ -1,0 +1,283 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.DevProxy.Abstractions;
+using System.Net;
+using System.Text.Json.Serialization;
+using System.Text.RegularExpressions;
+using Titanium.Web.Proxy.EventArguments;
+using Titanium.Web.Proxy.Http;
+using Titanium.Web.Proxy.Models;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.DevProxy.Plugins.MockResponses;
+
+public enum CrudApiActionType
+{
+    Create,
+    GetAll,
+    GetOne,
+    Merge,
+    Update,
+    Delete
+}
+
+public class CrudApiAction
+{
+    [JsonPropertyName("action")]
+    [System.Text.Json.Serialization.JsonConverter(typeof(JsonStringEnumConverter))]
+    public CrudApiActionType Action { get; set; } = CrudApiActionType.GetAll;
+    [JsonPropertyName("url")]
+    public string Url { get; set; } = string.Empty;
+    [JsonPropertyName("method")]
+    public string? Method { get; set; }
+    [JsonPropertyName("query")]
+    public string Query { get; set; } = string.Empty;
+}
+
+public class CrudApiConfiguration
+{
+    [JsonPropertyName("apiFile")]
+    public string ApiFile { get; set; } = "api.json";
+    [JsonPropertyName("baseUrl")]
+    public string BaseUrl { get; set; } = string.Empty;
+    [JsonPropertyName("dataFile")]
+    public string DataFile { get; set; } = string.Empty;
+    [JsonPropertyName("actions")]
+    public IEnumerable<CrudApiAction> Actions { get; set; } = Array.Empty<CrudApiAction>();
+}
+
+public class CrudApiPlugin : BaseProxyPlugin
+{
+    protected CrudApiConfiguration _configuration = new();
+    private CrudApiDefinitionLoader? _loader = null;
+    public override string Name => nameof(CrudApiPlugin);
+    private IProxyConfiguration? _proxyConfiguration;
+    private JArray? _data;
+
+    public override void Register(IPluginEvents pluginEvents,
+                            IProxyContext context,
+                            ISet<UrlToWatch> urlsToWatch,
+                            IConfigurationSection? configSection = null)
+    {
+        base.Register(pluginEvents, context, urlsToWatch, configSection);
+
+        configSection?.Bind(_configuration);
+
+        pluginEvents.BeforeRequest += OnRequest;
+
+        _proxyConfiguration = context.Configuration;
+
+        _configuration.ApiFile = Path.GetFullPath(ProxyUtils.ReplacePathTokens(_configuration.ApiFile), Path.GetDirectoryName(_proxyConfiguration?.ConfigFile ?? string.Empty) ?? string.Empty);
+
+        _loader = new CrudApiDefinitionLoader(_logger!, _configuration);
+        _loader?.InitApiDefinitionWatcher();
+
+        LoadData();
+    }
+
+    private void LoadData()
+    {
+        try
+        {
+            var dataFilePath = Path.GetFullPath(ProxyUtils.ReplacePathTokens(_configuration.DataFile), Path.GetDirectoryName(_proxyConfiguration?.ConfigFile ?? string.Empty) ?? string.Empty);
+            if (!File.Exists(dataFilePath))
+            {
+                _logger?.LogWarn($"File {dataFilePath} not found. CRUD API will be disabled");
+                _configuration.Actions = Array.Empty<CrudApiAction>();
+                return;
+            }
+
+            var dataString = File.ReadAllText(dataFilePath);
+            _data = JArray.Parse(dataString);
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogError($"An error has occurred while reading {_configuration.DataFile}:");
+            _logger?.LogError(ex.Message);
+        }
+    }
+
+    protected virtual Task OnRequest(object? sender, ProxyRequestArgs e)
+    {
+        Request request = e.Session.HttpClient.Request;
+        ResponseState state = e.ResponseState;
+
+        if (_urlsToWatch is not null && e.ShouldExecute(_urlsToWatch))
+        {
+            var actionAndParams = GetMatchingActionHandler(request);
+            if (actionAndParams is not null)
+            {
+                actionAndParams.Item1(e.Session, actionAndParams.Item2, actionAndParams.Item3);
+                state.HasBeenSet = true;
+            }
+        }
+
+        return Task.CompletedTask;
+    }
+
+    private void SendNotFoundResponse(SessionEventArgs e)
+    {
+        SendJsonResponse("{\"error\":{\"message\":\"Not found\"}}", HttpStatusCode.NotFound, e);
+    }
+
+    private string ReplaceParams(string query, IDictionary<string, string> parameters)
+    {
+        var result = Regex.Replace(query, "{([^}]+)}", new MatchEvaluator(m =>
+        {
+            return $"{{{m.Groups[1].Value.Replace('-', '_')}}}";
+        }));
+        foreach (var param in parameters)
+        {
+            result = result.Replace($"{{{param.Key}}}", param.Value);
+        }
+        return result;
+    }
+
+    private void SendJsonResponse(string body, HttpStatusCode statusCode, SessionEventArgs e)
+    {
+        e.GenericResponse(body, statusCode, new List<HttpHeader> { new HttpHeader("content-type", "application/json") });
+    }
+
+    private void GetAll(SessionEventArgs e, CrudApiAction action, IDictionary<string, string> parameters)
+    {
+        SendJsonResponse(JsonConvert.SerializeObject(_data, Formatting.Indented), HttpStatusCode.OK, e);
+        _logger?.LogRequest([$"200 {action.Url}"], MessageType.Mocked, new LoggingContext(e));
+    }
+
+    private void GetOne(SessionEventArgs e, CrudApiAction action, IDictionary<string, string> parameters)
+    {
+        var item = _data?.SelectToken(ReplaceParams(action.Query, parameters));
+        if (item is null)
+        {
+            SendNotFoundResponse(e);
+            _logger?.LogRequest([$"404 {action.Url}"], MessageType.Mocked, new LoggingContext(e));
+            return;
+        }
+
+        SendJsonResponse(JsonConvert.SerializeObject(item, Formatting.Indented), HttpStatusCode.OK, e);
+        _logger?.LogRequest([$"200 {action.Url}"], MessageType.Mocked, new LoggingContext(e));
+    }
+
+    private void Create(SessionEventArgs e, CrudApiAction action, IDictionary<string, string> parameters)
+    {
+        _data?.Add(JObject.Parse(e.HttpClient.Request.BodyString));
+        SendJsonResponse(JsonConvert.SerializeObject(e.HttpClient.Request.BodyString, Formatting.Indented), HttpStatusCode.Created, e);
+        _logger?.LogRequest([$"201 {action.Url}"], MessageType.Mocked, new LoggingContext(e));
+    }
+
+    private void Merge(SessionEventArgs e, CrudApiAction action, IDictionary<string, string> parameters)
+    {
+        var item = _data?.SelectToken(ReplaceParams(action.Query, parameters));
+        if (item is null)
+        {
+            SendNotFoundResponse(e);
+            _logger?.LogRequest([$"404 {action.Url}"], MessageType.Mocked, new LoggingContext(e));
+            return;
+        }
+        var update = JObject.Parse(e.HttpClient.Request.BodyString);
+        ((JContainer)item)?.Merge(update);
+        e.GenericResponse("", HttpStatusCode.NoContent);
+        _logger?.LogRequest([$"204 {action.Url}"], MessageType.Mocked, new LoggingContext(e));
+    }
+
+    private void Update(SessionEventArgs e, CrudApiAction action, IDictionary<string, string> parameters)
+    {
+        var item = _data?.SelectToken(ReplaceParams(action.Query, parameters));
+        if (item is null)
+        {
+            SendNotFoundResponse(e);
+            _logger?.LogRequest([$"404 {action.Url}"], MessageType.Mocked, new LoggingContext(e));
+            return;
+        }
+        var update = JObject.Parse(e.HttpClient.Request.BodyString);
+        ((JContainer)item)?.Replace(update);
+        e.GenericResponse("", HttpStatusCode.NoContent);
+        _logger?.LogRequest([$"204 {action.Url}"], MessageType.Mocked, new LoggingContext(e));
+    }
+
+    private void Delete(SessionEventArgs e, CrudApiAction action, IDictionary<string, string> parameters)
+    {
+        var item = _data?.SelectToken(ReplaceParams(action.Query, parameters));
+        if (item is null)
+        {
+            SendNotFoundResponse(e);
+            _logger?.LogRequest([$"404 {action.Url}"], MessageType.Mocked, new LoggingContext(e));
+            return;
+        }
+
+        item?.Remove();
+        e.GenericResponse("", HttpStatusCode.NoContent);
+        _logger?.LogRequest([$"204 {action.Url}"], MessageType.Mocked, new LoggingContext(e));
+    }
+
+    private Tuple<Action<SessionEventArgs, CrudApiAction, IDictionary<string, string>>, CrudApiAction, IDictionary<string, string>>? GetMatchingActionHandler(Request request)
+    {
+        if (_configuration.Actions is null ||
+            !_configuration.Actions.Any())
+        {
+            return null;
+        }
+
+        var parameterMatchEvaluator = new MatchEvaluator(m =>
+        {
+            var paramName = m.Value.Trim('{', '}').Replace('-', '_');
+            return $"(?<{paramName}>[^/&]+)";
+        });
+
+        var parameters = new Dictionary<string, string>();
+        var action = _configuration.Actions.FirstOrDefault(action =>
+        {
+            if (action.Method != request.Method) return false;
+            var absoluteActionUrl = (_configuration.BaseUrl.TrimEnd('/') + "/" + action.Url.TrimStart('/')).TrimEnd('/');
+
+            if (absoluteActionUrl == request.Url)
+            {
+                return true;
+            }
+
+            // check if the action contains parameters
+            // if it doesn't, it's not a match for the current request for sure
+            if (!absoluteActionUrl.Contains('{'))
+            {
+                return false;
+            }
+
+            // convert parameters into named regex groups
+            var urlRegex = Regex.Replace(Regex.Escape(absoluteActionUrl).Replace("\\{", "{"), "({[^}]+})", parameterMatchEvaluator);
+            var match = Regex.Match(request.Url, urlRegex);
+            if (!match.Success)
+            {
+                return false;
+            }
+
+            foreach (var groupName in match.Groups.Keys)
+            {
+                if (groupName == "0")
+                {
+                    continue;
+                }
+                parameters.Add(groupName, match.Groups[groupName].Value);
+            }
+            return true;
+        });
+
+        if (action is null)
+        {
+            return null;
+        }
+
+        return new Tuple<Action<SessionEventArgs, CrudApiAction, IDictionary<string, string>>, CrudApiAction, IDictionary<string, string>>(action.Action switch
+        {
+            CrudApiActionType.Create => Create,
+            CrudApiActionType.GetAll => GetAll,
+            CrudApiActionType.GetOne => GetOne,
+            CrudApiActionType.Merge => Merge,
+            CrudApiActionType.Update => Update,
+            CrudApiActionType.Delete => Delete,
+            _ => throw new NotImplementedException()
+        }, action, parameters);
+    }
+}

--- a/dev-proxy-plugins/dev-proxy-plugins.csproj
+++ b/dev-proxy-plugins/dev-proxy-plugins.csproj
@@ -25,6 +25,10 @@
       <Private>false</Private>
       <ExcludeAssets>runtime</ExcludeAssets>
     </PackageReference>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3">
+      <Private>false</Private>
+      <ExcludeAssets>runtime</ExcludeAssets>
+    </PackageReference>
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1">
       <Private>false</Private>
       <ExcludeAssets>runtime</ExcludeAssets>

--- a/dev-proxy/dev-proxy.csproj
+++ b/dev-proxy/dev-proxy.csproj
@@ -34,6 +34,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
     <PackageReference Include="Microsoft.OpenApi.Readers" Version="1.6.11" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.0.3" />
     <PackageReference Include="Titanium.Web.Proxy" Version="3.2.0" />

--- a/schemas/v1.0/crudapi.schema.json
+++ b/schemas/v1.0/crudapi.schema.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "CRUD API plugin API definition",
+  "description": "API definition for use with the CRUD API Dev Proxy plugin",
+  "type": "object",
+  "properties": {
+    "baseUrl": {
+      "type": "string"
+    },
+    "dataFile": {
+      "type": "string"
+    },
+    "actions": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "action": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          },
+          "query": {
+            "type": "string"
+          },
+          "method": {
+            "type": "string",
+            "enum": ["GET", "POST", "PUT", "PATCH", "DELETE"]
+          }
+        },
+        "required": ["action"],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": ["baseUrl", "dataFile", "actions"],
+  "additionalProperties": false
+}


### PR DESCRIPTION
Use the samples files from https://gist.github.com/waldekmastykarz/068de4b66a03e13ead22983070490b59 to test.

Calls to run:

```sh
# get all customers
curl -ix http://127.0.0.1:8000 https://api.contoso.com/v1/customers
# get one customer by ID
curl -ix http://127.0.0.1:8000 https://api.contoso.com/v1/customers/1
# add new customer
curl -ix http://127.0.0.1:8000 -X POST -d '{"id": 1200, "firstName": "Steve"}' https://api.contoso.com/v1/customers
# update select customer properties
curl -ix http://127.0.0.1:8000 -X PATCH -d '{"firstName": "Bob"}' https://api.contoso.com/v1/customers/1200
# replace customer with another
curl -ix http://127.0.0.1:8000 -X PUT -d '{"id": 1300, "firstName": "Henry"}' https://api.contoso.com/v1/customers/1200
# delete a customer
curl -ix http://127.0.0.1:8000 -X DELETE https://api.contoso.com/v1/customers/1300
```

Queries are built using JSONPath