### PR TITLE
Align response objects in schemas

### DIFF
--- a/schemas/v1.0/genericrandomerrorplugin.schema.json
+++ b/schemas/v1.0/genericrandomerrorplugin.schema.json
@@ -39,11 +39,7 @@
               ]
             }
           }
-        },
-        "required": [
-          "statusCode",
-          "body"
-        ]
+        }
       }
     }
   },

--- a/schemas/v1.0/mockresponseplugin.schema.json
+++ b/schemas/v1.0/mockresponseplugin.schema.json
@@ -70,11 +70,7 @@
                   ]
                 }
               }
-            },
-            "required": [
-              "statusCode",
-              "body"
-            ]
+            }
           }
         },
         "required": [

--- a/schemas/v1.0/mockresponseplugin.schema.json
+++ b/schemas/v1.0/mockresponseplugin.schema.json
@@ -5,7 +5,7 @@
   "type": "object",
   "properties": {
     "$schema": {
-      "type":"string"
+      "type": "string"
     },
     "mocks": {
       "type": "array",
@@ -41,33 +41,40 @@
             ]
           },
           "response": {
-            "body": {
-              "type": [
-                "object",
-                "string"
-              ]
-            },
-            "code": {
-              "type": "integer"
-            },
-            "headers": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "name": {
-                    "type": "string"
-                  },
-                  "value": {
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "name",
-                  "value"
+            "type": "object",
+            "properties": {
+              "body": {
+                "type": [
+                  "object",
+                  "string"
                 ]
+              },
+              "statusCode": {
+                "type": "integer"
+              },
+              "headers": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "name",
+                    "value"
+                  ]
+                }
               }
-            }
+            },
+            "required": [
+              "statusCode",
+              "body"
+            ]
           }
         },
         "required": [


### PR DESCRIPTION
Merging this PR will align the response objects used in both `mockresponseplugn.schema.json ` and `genericrandomerrorplugin.schema.json`