### PR TITLE
Adds permissions to address GH change

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -51,6 +51,8 @@ jobs:
     environment:
       name: gh_releases
     runs-on: [windows-latest]
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v3
       - uses: actions/download-artifact@v3


### PR DESCRIPTION
Adds permissions to address this breaking change in GH: https://docs.opensource.microsoft.com/github/apps/permission-changes/.

Let's validate if we've got everything. As far as I can tell, we only need write permission for contents to create a release, but let's double check.