### PR TITLE
Sets default CrudApiPlugin encoding to utf-8. Closes #518

### DIFF
--- a/dev-proxy-plugins/MockResponses/CrudApiPlugin.cs
+++ b/dev-proxy-plugins/MockResponses/CrudApiPlugin.cs
@@ -149,7 +149,7 @@ public class CrudApiPlugin : BaseProxyPlugin
     private void SendJsonResponse(string body, HttpStatusCode statusCode, SessionEventArgs e)
     {
         var headers = new List<HttpHeader> {
-            new HttpHeader("content-type", "application/json")
+            new HttpHeader("content-type", "application/json; charset=utf-8")
         };
         if (e.HttpClient.Request.Headers.Any(h => h.Name == "Origin"))
         {


### PR DESCRIPTION
Sets default CrudApiPlugin encoding to utf-8. Closes #518