### PR TITLE
When plugin defines an empty array of URLs to watch, use the global o…

### DIFF
--- a/dev-proxy/PluginLoader.cs
+++ b/dev-proxy/PluginLoader.cs
@@ -52,7 +52,12 @@ internal class PluginLoader
                 }
                 // Load Plugins from assembly
                 IProxyPlugin plugin = CreatePlugin(assembly, h);
-                plugin.Register(pluginEvents,proxyContext,pluginUrls is not null && pluginUrls.Any() ? pluginUrls : defaultUrlsToWatch,h.ConfigSection is null ? null : Configuration.GetSection(h.ConfigSection));
+                plugin.Register(
+                    pluginEvents,
+                    proxyContext,
+                    (pluginUrls != null && pluginUrls.Count > 0) ? pluginUrls : defaultUrlsToWatch,
+                    h.ConfigSection is null ? null : Configuration.GetSection(h.ConfigSection)
+                );
                 plugins.Add(plugin);
             }
         }

--- a/dev-proxy/PluginLoader.cs
+++ b/dev-proxy/PluginLoader.cs
@@ -45,8 +45,11 @@ internal class PluginLoader
                 Assembly assembly = pluginLoadContext.LoadFromAssemblyName(new AssemblyName(Path.GetFileNameWithoutExtension(pluginLocation)));
                 IEnumerable<UrlToWatch>? pluginUrlsList = h.UrlsToWatch?.Select(ConvertToRegex);
                 ISet<UrlToWatch>? pluginUrls = null;
-                if (pluginUrlsList is not null)
-                {
+                if (pluginUrlsList is null || !pluginUrlsList.Any()){
+                    pluginUrlsList = globalUrlsToWatch.ToList();
+                }
+
+                if (pluginUrlsList.Any()){
                     pluginUrls = pluginUrlsList.ToHashSet();
                     globallyWatchedUrls.AddRange(pluginUrlsList);
                 }

--- a/dev-proxy/PluginLoader.cs
+++ b/dev-proxy/PluginLoader.cs
@@ -45,17 +45,14 @@ internal class PluginLoader
                 Assembly assembly = pluginLoadContext.LoadFromAssemblyName(new AssemblyName(Path.GetFileNameWithoutExtension(pluginLocation)));
                 IEnumerable<UrlToWatch>? pluginUrlsList = h.UrlsToWatch?.Select(ConvertToRegex);
                 ISet<UrlToWatch>? pluginUrls = null;
-                if (pluginUrlsList is null || !pluginUrlsList.Any()){
-                    pluginUrlsList = globalUrlsToWatch.ToList();
-                }
-
-                if (pluginUrlsList.Any()){
+                if (pluginUrlsList is not null)
+                {
                     pluginUrls = pluginUrlsList.ToHashSet();
                     globallyWatchedUrls.AddRange(pluginUrlsList);
                 }
                 // Load Plugins from assembly
                 IProxyPlugin plugin = CreatePlugin(assembly, h);
-                plugin.Register(pluginEvents, proxyContext, pluginUrls ?? defaultUrlsToWatch, h.ConfigSection is null ? null : Configuration.GetSection(h.ConfigSection));
+                plugin.Register(pluginEvents,proxyContext,pluginUrls is not null && pluginUrls.Any() ? pluginUrls : defaultUrlsToWatch,h.ConfigSection is null ? null : Configuration.GetSection(h.ConfigSection));
                 plugins.Add(plugin);
             }
         }


### PR DESCRIPTION
…ne #527

Checking for Null or Empty:

The first if statement checks if pluginUrlsList is either null or empty.
If it's null or empty, it sets pluginUrlsList to the global list of URLs (globalUrlsToWatch.ToList()).
Processing Non-Empty List:

The second if statement checks if pluginUrlsList has any elements.
If it has elements, it processes the non-empty pluginUrlsList.
This modification ensures that even if the plugin defines an empty array of URLs, the code will not consider the plugin "disabled." Instead, it defaults to using the global list of URLs, preventing confusion and ensuring that there is always a valid list for further processing.