### PR TITLE
Fix handling of empty 'urlsToWatch' in plugins

### DIFF
--- a/dev-proxy/PluginLoader.cs
+++ b/dev-proxy/PluginLoader.cs
@@ -52,7 +52,12 @@ internal class PluginLoader
                 }
                 // Load Plugins from assembly
                 IProxyPlugin plugin = CreatePlugin(assembly, h);
-                plugin.Register(pluginEvents,proxyContext,pluginUrls is not null && pluginUrls.Any() ? pluginUrls : defaultUrlsToWatch,h.ConfigSection is null ? null : Configuration.GetSection(h.ConfigSection));
+                plugin.Register(
+                    pluginEvents,
+                    proxyContext,
+                    (pluginUrls != null && pluginUrls.Count > 0) ? pluginUrls : defaultUrlsToWatch,
+                    h.ConfigSection is null ? null : Configuration.GetSection(h.ConfigSection)
+                );
                 plugins.Add(plugin);
             }
         }

--- a/dev-proxy/PluginLoader.cs
+++ b/dev-proxy/PluginLoader.cs
@@ -45,8 +45,11 @@ internal class PluginLoader
                 Assembly assembly = pluginLoadContext.LoadFromAssemblyName(new AssemblyName(Path.GetFileNameWithoutExtension(pluginLocation)));
                 IEnumerable<UrlToWatch>? pluginUrlsList = h.UrlsToWatch?.Select(ConvertToRegex);
                 ISet<UrlToWatch>? pluginUrls = null;
-                if (pluginUrlsList is not null)
-                {
+                if (pluginUrlsList is null || !pluginUrlsList.Any()){
+                    pluginUrlsList = globalUrlsToWatch.ToList();
+                }
+
+                if (pluginUrlsList.Any()){
                     pluginUrls = pluginUrlsList.ToHashSet();
                     globallyWatchedUrls.AddRange(pluginUrlsList);
                 }

--- a/dev-proxy/PluginLoader.cs
+++ b/dev-proxy/PluginLoader.cs
@@ -45,17 +45,14 @@ internal class PluginLoader
                 Assembly assembly = pluginLoadContext.LoadFromAssemblyName(new AssemblyName(Path.GetFileNameWithoutExtension(pluginLocation)));
                 IEnumerable<UrlToWatch>? pluginUrlsList = h.UrlsToWatch?.Select(ConvertToRegex);
                 ISet<UrlToWatch>? pluginUrls = null;
-                if (pluginUrlsList is null || !pluginUrlsList.Any()){
-                    pluginUrlsList = globalUrlsToWatch.ToList();
-                }
-
-                if (pluginUrlsList.Any()){
+                if (pluginUrlsList is not null)
+                {
                     pluginUrls = pluginUrlsList.ToHashSet();
                     globallyWatchedUrls.AddRange(pluginUrlsList);
                 }
                 // Load Plugins from assembly
                 IProxyPlugin plugin = CreatePlugin(assembly, h);
-                plugin.Register(pluginEvents, proxyContext, pluginUrls ?? defaultUrlsToWatch, h.ConfigSection is null ? null : Configuration.GetSection(h.ConfigSection));
+                plugin.Register(pluginEvents,proxyContext,pluginUrls is not null && pluginUrls.Any() ? pluginUrls : defaultUrlsToWatch,h.ConfigSection is null ? null : Configuration.GetSection(h.ConfigSection));
                 plugins.Add(plugin);
             }
         }

--- a/dev-proxy/PluginLoader.cs
+++ b/dev-proxy/PluginLoader.cs
@@ -55,7 +55,7 @@ internal class PluginLoader
                 plugin.Register(
                     pluginEvents,
                     proxyContext,
-                    (pluginUrls != null && pluginUrls.Count > 0) ? pluginUrls : defaultUrlsToWatch,
+                    (pluginUrls != null && pluginUrls.Any()) ? pluginUrls : defaultUrlsToWatch,
                     h.ConfigSection is null ? null : Configuration.GetSection(h.ConfigSection)
                 );
                 plugins.Add(plugin);


### PR DESCRIPTION
Issue #527 

This commit resolves an issue where plugins defining an empty array for 'urlsToWatch' would result in the plugin being disabled. The code has been modified to check for both null and empty arrays, and in both cases, it now defaults to using the global list of URLs. This ensures that plugins remain active even when no specific URLs are provided.

- Modified the code to handle empty 'urlsToWatch' arrays.
- Added a check for both null and empty arrays.
- Plugins now default to using the global list of URLs when 'urlsToWatch' is empty.

Let's confirm this:

```
{
  "$schema": "https://raw.githubusercontent.com/microsoft/dev-proxy/main/schemas/v0.15.0/rc.schema.json",
  "plugins": [
    {
      "name": "RetryAfterPlugin",
      "enabled": true,
      "pluginPath": "plugins\\dev-proxy-plugins.dll"
    },
    {
      "name": "GenericRandomErrorPlugin",
      "enabled": true,
      "pluginPath": "plugins\\dev-proxy-plugins.dll",
      "configSection": "genericRandomErrorPlugin",
      "urlsToWatch": []  // Empty array indicates that it now defaults to using the global list of URLs
    }
  ],
  "urlsToWatch": [
    "https://jsonplaceholder.typicode.com/*"
  ],
  "genericRandomErrorPlugin": {
    "errorsFile": "devproxy-errors.json"
  },
  "rate": 50,
  "labelMode": "text",
  "logLevel": "info",
  "newVersionNotification": "stable"
}

```

As you can see, I have added a comment to the urlsToWatch array in the GenericRandomErrorPlugin block to explicitly state that the empty array indicates that it now defaults to using the global list of URLs. This helps in providing a clear and concise explanation of the purpose of the empty array.

Now let's test 

![image](https://github.com/microsoft/dev-proxy/assets/157403288/efb65d22-9375-4e96-8e49-03426f1e1631)

Now let's change it 
```
{
  "$schema": "https://raw.githubusercontent.com/microsoft/dev-proxy/main/schemas/v0.15.0/rc.schema.json",
  "plugins": [
    {
      "name": "RetryAfterPlugin",
      "enabled": true,
      "pluginPath": "plugins\\dev-proxy-plugins.dll",
      "urlsToWatch": []  // Empty array indicates that it now defaults to using the global list of URLs
    },
    {
      "name": "GenericRandomErrorPlugin",
      "enabled": true,
      "pluginPath": "plugins\\dev-proxy-plugins.dll",
      "configSection": "genericRandomErrorPlugin",
   
    }
```
![image](https://github.com/microsoft/dev-proxy/assets/157403288/a301527d-c0ad-48a5-a111-676250dd1933)



Ealier Code
```
plugin.Register(pluginEvents, proxyContext, pluginUrls ?? defaultUrlsToWatch, h.ConfigSection is null ? null : Configuration.GetSection(h.ConfigSection));

```
Changes Made:

```
plugin.Register(
    pluginEvents,
    proxyContext,
    (pluginUrls != null && pluginUrls.Count > 0) ? pluginUrls : defaultUrlsToWatch,
    h.ConfigSection is null ? null : Configuration.GetSection(h.ConfigSection)
);

```


