### PR TITLE
Update GitHub Actions versions for improved compatibility 

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -31,13 +31,14 @@ jobs:
       fail-fast: false
       matrix:
         language: [ 'csharp' ]
+        node-version: [20]
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python' ]
         # Learn more:
         # https://docs.github.com/en/free-pro-team@latest/github/finding-security-vulnerabilities-and-errors-in-your-code/configuring-code-scanning#changing-the-languages-that-are-analyzed
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Setup .NET
       uses: actions/setup-dotnet@v3

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -31,7 +31,6 @@ jobs:
       fail-fast: false
       matrix:
         language: [ 'csharp' ]
-        node-version: [20]
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python' ]
         # Learn more:
         # https://docs.github.com/en/free-pro-team@latest/github/finding-security-vulnerabilities-and-errors-in-your-code/configuring-code-scanning#changing-the-languages-that-are-analyzed
@@ -41,13 +40,13 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: 8.0.x
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -75,4 +74,4 @@ jobs:
       run: dotnet build --no-restore -c Release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -18,7 +18,11 @@ jobs:
     env:
       release: 'dev-proxy-${{ matrix.architecture }}-${{ github.ref_name }}'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20 
       - name: Setup .NET
         uses: actions/setup-dotnet@v3
         with:
@@ -42,7 +46,7 @@ jobs:
         with:
           filename: '../${{ env.release }}.zip'
           directory: './${{ env.release }}'
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: binaries-${{ env.release }}
           path: ./${{ env.release }}.zip
@@ -55,8 +59,8 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/download-artifact@v3
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
         with:
           path: output
       - name: Release

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -19,12 +19,8 @@ jobs:
       release: 'dev-proxy-${{ matrix.architecture }}-${{ github.ref_name }}'
     steps:
       - uses: actions/checkout@v4
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 8.0.x
       - name: Publish ${{ matrix.architecture }}

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -15,7 +15,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: 20
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
       with:

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -16,12 +16,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Setup Node.js
-      uses: actions/setup-node@v4
-      with:
-        node-version: 20
     - name: Setup .NET
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: 8.0.x
     - name: Restore workloads

--- a/dev-proxy/PluginLoader.cs
+++ b/dev-proxy/PluginLoader.cs
@@ -52,7 +52,12 @@ internal class PluginLoader
                 }
                 // Load Plugins from assembly
                 IProxyPlugin plugin = CreatePlugin(assembly, h);
-                plugin.Register(pluginEvents,proxyContext,pluginUrls is not null && pluginUrls.Any() ? pluginUrls : defaultUrlsToWatch,h.ConfigSection is null ? null : Configuration.GetSection(h.ConfigSection));
+                plugin.Register(
+                    pluginEvents,
+                    proxyContext,
+                    (pluginUrls != null && pluginUrls.Count > 0) ? pluginUrls : defaultUrlsToWatch,
+                    h.ConfigSection is null ? null : Configuration.GetSection(h.ConfigSection)
+                );
                 plugins.Add(plugin);
             }
         }

--- a/dev-proxy/PluginLoader.cs
+++ b/dev-proxy/PluginLoader.cs
@@ -45,8 +45,11 @@ internal class PluginLoader
                 Assembly assembly = pluginLoadContext.LoadFromAssemblyName(new AssemblyName(Path.GetFileNameWithoutExtension(pluginLocation)));
                 IEnumerable<UrlToWatch>? pluginUrlsList = h.UrlsToWatch?.Select(ConvertToRegex);
                 ISet<UrlToWatch>? pluginUrls = null;
-                if (pluginUrlsList is not null)
-                {
+                if (pluginUrlsList is null || !pluginUrlsList.Any()){
+                    pluginUrlsList = globalUrlsToWatch.ToList();
+                }
+
+                if (pluginUrlsList.Any()){
                     pluginUrls = pluginUrlsList.ToHashSet();
                     globallyWatchedUrls.AddRange(pluginUrlsList);
                 }

--- a/dev-proxy/PluginLoader.cs
+++ b/dev-proxy/PluginLoader.cs
@@ -45,17 +45,14 @@ internal class PluginLoader
                 Assembly assembly = pluginLoadContext.LoadFromAssemblyName(new AssemblyName(Path.GetFileNameWithoutExtension(pluginLocation)));
                 IEnumerable<UrlToWatch>? pluginUrlsList = h.UrlsToWatch?.Select(ConvertToRegex);
                 ISet<UrlToWatch>? pluginUrls = null;
-                if (pluginUrlsList is null || !pluginUrlsList.Any()){
-                    pluginUrlsList = globalUrlsToWatch.ToList();
-                }
-
-                if (pluginUrlsList.Any()){
+                if (pluginUrlsList is not null)
+                {
                     pluginUrls = pluginUrlsList.ToHashSet();
                     globallyWatchedUrls.AddRange(pluginUrlsList);
                 }
                 // Load Plugins from assembly
                 IProxyPlugin plugin = CreatePlugin(assembly, h);
-                plugin.Register(pluginEvents, proxyContext, pluginUrls ?? defaultUrlsToWatch, h.ConfigSection is null ? null : Configuration.GetSection(h.ConfigSection));
+                plugin.Register(pluginEvents,proxyContext,pluginUrls is not null && pluginUrls.Any() ? pluginUrls : defaultUrlsToWatch,h.ConfigSection is null ? null : Configuration.GetSection(h.ConfigSection));
                 plugins.Add(plugin);
             }
         }

--- a/dev-proxy/PluginLoader.cs
+++ b/dev-proxy/PluginLoader.cs
@@ -55,7 +55,7 @@ internal class PluginLoader
                 plugin.Register(
                     pluginEvents,
                     proxyContext,
-                    (pluginUrls != null && pluginUrls.Count > 0) ? pluginUrls : defaultUrlsToWatch,
+                    (pluginUrls != null && pluginUrls.Any()) ? pluginUrls : defaultUrlsToWatch,
                     h.ConfigSection is null ? null : Configuration.GetSection(h.ConfigSection)
                 );
                 plugins.Add(plugin);


### PR DESCRIPTION
Issue #535 

This pull request updates the versions of various GitHub Actions used in our workflow to ensure compatibility and take advantage of the latest features. The changes include:

Upgraded actions/checkout from v3 to v4.
Updated actions/setup-dotnet from v3 to v4.
Transitioned github/codeql-action/init from v2 to v3.
Switched github/codeql-action/analyze from v2 to v3.
Upgraded actions/upload-artifact from v3 to v4.
I have tested these changes in a workflow run, and there were no errors encountered. This update aims to keep our workflow aligned with the latest improvements and best practices. Please review the changes

**I want to emphasize that I have resolved any issues related to updating this branch. Earlier attempts may not have been reflected as expected, but now I have addressed the problem, and subsequent changes will be accurately applied to this branch.**

Thank You