### PR TITLE
Adds M365 mock response plugin

### DIFF
--- a/dev-proxy-abstractions/GraphBatchResponsePayload.cs
+++ b/dev-proxy-abstractions/GraphBatchResponsePayload.cs
@@ -20,7 +20,7 @@ public class GraphBatchResponsePayloadResponse
     [JsonPropertyName("body")]
     public dynamic? Body { get; set; }
     [JsonPropertyName("headers")]
-    public List<MockResponseHeader>? Headers { get; set; }
+    public Dictionary<string, string>? Headers { get; set; }
 }
 
 public class GraphBatchResponsePayloadResponseBody

--- a/dev-proxy-abstractions/ProxyUtils.cs
+++ b/dev-proxy-abstractions/ProxyUtils.cs
@@ -309,7 +309,8 @@ public static class ProxyUtils
             var existingHeader = allHeaders.FirstOrDefault(h => h.Name.Equals(header.Name, StringComparison.OrdinalIgnoreCase));
             if (existingHeader is not null)
             {
-                if (header.Name.Equals("Access-Control-Expose-Headers", StringComparison.OrdinalIgnoreCase))
+                if (header.Name.Equals("Access-Control-Expose-Headers", StringComparison.OrdinalIgnoreCase) ||
+                    header.Name.Equals("Access-Control-Allow-Headers", StringComparison.OrdinalIgnoreCase))
                 {
                     var existingValues = existingHeader.Value.Split(',').Select(v => v.Trim());
                     var newValues = header.Value.Split(',').Select(v => v.Trim());

--- a/dev-proxy-plugins/MockResponses/M365MockResponsePlugin.cs
+++ b/dev-proxy-plugins/MockResponses/M365MockResponsePlugin.cs
@@ -1,0 +1,124 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.RegularExpressions;
+using System.Web;
+using Microsoft.DevProxy.Abstractions;
+
+namespace Microsoft.DevProxy.Plugins.MockResponses;
+
+class IdToken {
+    [JsonPropertyName("aud")]
+    public string? Aud { get; set; }
+    [JsonPropertyName("iss")]
+    public string? Iss { get; set; }
+    [JsonPropertyName("iat")]
+    public int? Iat { get; set; }
+    [JsonPropertyName("nbf")]
+    public int? Nbf { get; set; }
+    [JsonPropertyName("exp")]
+    public int? Exp { get; set; }
+    [JsonPropertyName("name")]
+    public string? Name { get; set; }
+    [JsonPropertyName("nonce")]
+    public string? Nonce { get; set; }
+    [JsonPropertyName("oid")]
+    public string? Oid { get; set; }
+    [JsonPropertyName("preferred_username")]
+    public string? PreferredUsername { get; set; }
+    [JsonPropertyName("rh")]
+    public string? Rh { get; set; }
+    [JsonPropertyName("sub")]
+    public string? Sub { get; set; }
+    [JsonPropertyName("tid")]
+    public string? Tid { get; set; }
+    [JsonPropertyName("uti")]
+    public string? Uti { get; set; }
+    [JsonPropertyName("ver")]
+    public string? Ver { get; set; }
+}
+
+public class M365MockResponsePlugin : GraphMockResponsePlugin
+{
+    private string? lastNonce;
+    public override string Name => nameof(M365MockResponsePlugin);
+
+    protected override void ProcessMockResponse(ref byte[] body, IList<MockResponseHeader> headers, ProxyRequestArgs e, MockResponse? matchingResponse)
+    {
+        base.ProcessMockResponse(ref body, headers, e, matchingResponse);
+
+        var bodyString = Encoding.UTF8.GetString(body);
+        var changed = false;
+
+        StoreLastNonce(e);
+        UpdateMsalState(ref bodyString, e, ref changed);
+        UpdateIdToken(ref bodyString, e, ref changed);
+
+        if (changed)
+        {
+            body = Encoding.UTF8.GetBytes(bodyString);
+        }
+    }
+
+    private void StoreLastNonce(ProxyRequestArgs e)
+    {
+        if (e.Session.HttpClient.Request.RequestUri.Query.Contains("nonce="))
+        {
+            var queryString = HttpUtility.ParseQueryString(e.Session.HttpClient.Request.RequestUri.Query);
+            lastNonce = queryString["nonce"];
+        }
+    }
+
+    private void UpdateIdToken(ref string body, ProxyRequestArgs e, ref bool changed)
+    {
+        if (!body.Contains("id_token\":\"@dynamic") ||
+            string.IsNullOrEmpty(lastNonce))
+        {
+            return;
+        }
+
+        var idTokenRegex = new Regex("id_token\":\"([^\"]+)\"");
+
+        var idToken = idTokenRegex.Match(body).Groups[1].Value;
+        idToken = idToken.Replace("@dynamic.", "");
+        var tokenChunks = idToken.Split('.');
+        // base64 decode the second chunk from the array
+        // before decoding, we need to pad the base64 to a multiple of 4
+        // or Convert.FromBase64String will throw an exception
+        var decodedToken = Encoding.UTF8.GetString(Convert.FromBase64String(PadBase64(tokenChunks[1])));
+        var token = JsonSerializer.Deserialize<IdToken>(decodedToken);
+        if (token is null)
+        {
+            return;
+        }
+        
+        token.Nonce = lastNonce;
+
+        tokenChunks[1] = Convert.ToBase64String(Encoding.UTF8.GetBytes(JsonSerializer.Serialize(token)));
+        body = idTokenRegex.Replace(body, $"id_token\":\"{string.Join('.', tokenChunks)}\"");
+        changed = true;
+    }
+
+    private string PadBase64(string base64)
+    {
+        var padding = new string('=', (4 - base64.Length % 4) % 4);
+        return base64 + padding;
+    }
+
+    private void UpdateMsalState(ref string body, ProxyRequestArgs e, ref bool changed)
+    {
+        if (!body.Contains("state=@dynamic") ||
+          !e.Session.HttpClient.Request.RequestUri.Query.Contains("state="))
+        {
+            return;
+        }
+
+        var queryString = HttpUtility.ParseQueryString(e.Session.HttpClient.Request.RequestUri.Query);
+        var msalState = queryString["state"];
+        body = body.Replace("state=@dynamic", $"state={msalState}");
+        changed = true;
+    }
+}

--- a/dev-proxy-plugins/RandomErrors/GraphRandomErrorPlugin.cs
+++ b/dev-proxy-plugins/RandomErrors/GraphRandomErrorPlugin.cs
@@ -149,7 +149,7 @@ public class GraphRandomErrorPlugin : BaseProxyPlugin
                     var requestUrl = ProxyUtils.GetAbsoluteRequestUrlFromBatch(e.Session.HttpClient.Request.RequestUri, request.Url);
                     var throttledRequests = e.GlobalData[RetryAfterPlugin.ThrottledRequestsKey] as List<ThrottlerInfo>;
                     throttledRequests?.Add(new ThrottlerInfo(GraphUtils.BuildThrottleKey(requestUrl), ShouldThrottle, retryAfterDate));
-                    response.Headers = new List<MockResponseHeader> { new("Retry-After", retryAfterInSeconds.ToString()) };
+                    response.Headers = new Dictionary<string, string> { { "Retry-After", retryAfterInSeconds.ToString() } };
                 }
 
                 responses.Add(response);

--- a/dev-proxy-plugins/RequestLogs/MockGeneratorPlugin.cs
+++ b/dev-proxy-plugins/RequestLogs/MockGeneratorPlugin.cs
@@ -136,7 +136,7 @@ public class MockGeneratorPlugin : BaseProxyPlugin
         // assume body is binary
         try
         {
-            var filename = $"response-{DateTime.Now:yyyyMMddHHmmss}.bin";
+            var filename = $"response-{Guid.NewGuid()}.bin";
             _logger?.LogDebug("Reading response body as bytes...");
             var body = await session.GetResponseBody();
             _logger?.LogDebug($"Writing response body to {filename}...");


### PR DESCRIPTION
Adds M365 mock response plugin
Fixes bug in MockGeneratorPlugin
Fixes bug in GraphMockResponsePlugin
Fixes bug in GraphRandomErrorPlugin
Makes MockResponsePlugin extensible
Fixes bug in merging CORS headers

The M365MockResponsePlugin is a temporary solution until we fixed #554. We can then rename it to `EntraMockResponsePlugin` and separate the Graph batching concerns from Entra.