### PR TITLE
Refactors passing global options into root command handler

### DIFF
--- a/dev-proxy/ProxyCommandHandler.cs
+++ b/dev-proxy/ProxyCommandHandler.cs
@@ -10,47 +10,16 @@ namespace Microsoft.DevProxy;
 
 public class ProxyCommandHandler : ICommandHandler
 {
-    public Option<int?> Port { get; set; }
-    public Option<string?> IPAddress { get; set; }
-    public Option<LogLevel?> LogLevel { get; set; }
-    public Option<bool?> Record { get; set; }
-    public Option<IEnumerable<int>?> WatchPids { get; set; }
-    public Option<IEnumerable<string>?> WatchProcessNames { get; set; }
-    public Option<int?> Rate { get; set; }
-    public Option<bool?> NoFirstRun { get; set; }
-    public Option<bool?> AsSystemProxy { get; set; }
-    public Option<bool?> InstallCert { get; set; }
-
     private readonly PluginEvents _pluginEvents;
     private readonly Option[] _options;
     private readonly ISet<UrlToWatch> _urlsToWatch;
     private readonly ILogger _logger;
 
-    public ProxyCommandHandler(Option<int?> port,
-                               Option<string?> ipAddress,
-                               Option<LogLevel?> logLevel,
-                               Option<bool?> record,
-                               Option<IEnumerable<int>?> watchPids,
-                               Option<IEnumerable<string>?> watchProcessNames,
-                               Option<int?> rate,
-                               Option<bool?> noFirstRun,
-                               Option<bool?> asSystemProxy,
-                               Option<bool?> installCert,
-                               PluginEvents pluginEvents,
+    public ProxyCommandHandler(PluginEvents pluginEvents,
                                Option[] options,
                                ISet<UrlToWatch> urlsToWatch,
                                ILogger logger)
     {
-        Port = port ?? throw new ArgumentNullException(nameof(port));
-        IPAddress = ipAddress ?? throw new ArgumentNullException(nameof(ipAddress));
-        LogLevel = logLevel ?? throw new ArgumentNullException(nameof(logLevel));
-        Record = record ?? throw new ArgumentNullException(nameof(record));
-        WatchPids = watchPids ?? throw new ArgumentNullException(nameof(watchPids));
-        WatchProcessNames = watchProcessNames ?? throw new ArgumentNullException(nameof(watchProcessNames));
-        Rate = rate ?? throw new ArgumentNullException(nameof(rate));
-        NoFirstRun = noFirstRun ?? throw new ArgumentNullException(nameof(noFirstRun));
-        AsSystemProxy = asSystemProxy ?? throw new ArgumentNullException(nameof(asSystemProxy));
-        InstallCert = installCert ?? throw new ArgumentNullException(nameof(installCert));
         _pluginEvents = pluginEvents ?? throw new ArgumentNullException(nameof(pluginEvents));
         _options = options ?? throw new ArgumentNullException(nameof(options));
         _urlsToWatch = urlsToWatch ?? throw new ArgumentNullException(nameof(urlsToWatch));
@@ -64,52 +33,52 @@ public class ProxyCommandHandler : ICommandHandler
 
     public async Task<int> InvokeAsync(InvocationContext context)
     {
-        var port = context.ParseResult.GetValueForOption(Port);
+        var port = context.ParseResult.GetValueForOption<int?>(ProxyHost.PortOptionName, _options);
         if (port is not null)
         {
             Configuration.Port = port.Value;
         }
-        var ipAddress = context.ParseResult.GetValueForOption(IPAddress);
+        var ipAddress = context.ParseResult.GetValueForOption<string?>(ProxyHost.IpAddressOptionName, _options);
         if (ipAddress is not null)
         {
             Configuration.IPAddress = ipAddress;
         }
-        var logLevel = context.ParseResult.GetValueForOption(LogLevel);
+        var logLevel = context.ParseResult.GetValueForOption<LogLevel?>(ProxyHost.LogLevelOptionName, _options);
         if (logLevel is not null)
         {
             _logger.LogLevel = logLevel.Value;
         }
-        var record = context.ParseResult.GetValueForOption(Record);
+        var record = context.ParseResult.GetValueForOption<bool?>(ProxyHost.RecordOptionName, _options);
         if (record is not null)
         {
             Configuration.Record = record.Value;
         }
-        var watchPids = context.ParseResult.GetValueForOption(WatchPids);
+        var watchPids = context.ParseResult.GetValueForOption<IEnumerable<int>?>(ProxyHost.WatchPidsOptionName, _options);
         if (watchPids is not null)
         {
             Configuration.WatchPids = watchPids;
         }
-        var watchProcessNames = context.ParseResult.GetValueForOption(WatchProcessNames);
+        var watchProcessNames = context.ParseResult.GetValueForOption<IEnumerable<string>?>(ProxyHost.WatchProcessNamesOptionName, _options);
         if (watchProcessNames is not null)
         {
             Configuration.WatchProcessNames = watchProcessNames;
         }
-        var rate = context.ParseResult.GetValueForOption(Rate);
+        var rate = context.ParseResult.GetValueForOption<int?>(ProxyHost.RateOptionName, _options);
         if (rate is not null)
         {
             Configuration.Rate = rate.Value;
         }
-        var noFirstRun = context.ParseResult.GetValueForOption(NoFirstRun);
+        var noFirstRun = context.ParseResult.GetValueForOption<bool?>(ProxyHost.NoFirstRunOptionName, _options);
         if (noFirstRun is not null)
         {
             Configuration.NoFirstRun = noFirstRun.Value;
         }
-        var asSystemProxy = context.ParseResult.GetValueForOption(AsSystemProxy);
+        var asSystemProxy = context.ParseResult.GetValueForOption<bool?>(ProxyHost.AsSystemProxyOptionName, _options);
         if (asSystemProxy is not null)
         {
             Configuration.AsSystemProxy = asSystemProxy.Value;
         }
-        var installCert = context.ParseResult.GetValueForOption(InstallCert);
+        var installCert = context.ParseResult.GetValueForOption<bool?>(ProxyHost.InstallCertOptionName, _options);
         if (installCert is not null)
         {
             Configuration.InstallCert = installCert.Value;

--- a/dev-proxy/ProxyHost.cs
+++ b/dev-proxy/ProxyHost.cs
@@ -3,24 +3,35 @@
 
 using Microsoft.DevProxy.Abstractions;
 using System.CommandLine;
-using System.CommandLine.Invocation;
 using System.Net;
 
 namespace Microsoft.DevProxy;
 
 internal class ProxyHost
 {
+    internal static readonly string PortOptionName = "--port";
     private Option<int?> _portOption;
+    internal static readonly string IpAddressOptionName = "--ip-address";
     private Option<string?> _ipAddressOption;
+    internal static readonly string LogLevelOptionName = "--log-level";
     private static Option<LogLevel?>? _logLevelOption;
+    internal static readonly string RecordOptionName = "--record";
     private Option<bool?> _recordOption;
+    internal static readonly string WatchPidsOptionName = "--watch-pids";
     private Option<IEnumerable<int>?> _watchPidsOption;
+    internal static readonly string WatchProcessNamesOptionName = "--watch-process-names";
     private Option<IEnumerable<string>?> _watchProcessNamesOption;
+    internal static readonly string ConfigFileOptionName = "--config-file";
     private static Option<string?>? _configFileOption;
+    internal static readonly string RateOptionName = "--failure-rate";
     private Option<int?> _rateOption;
+    internal static readonly string NoFirstRunOptionName = "--no-first-run";
     private Option<bool?> _noFirstRunOption;
+    internal static readonly string AsSystemProxyOptionName = "--as-system-proxy";
     private Option<bool?> _asSystemProxyOption;
+    internal static readonly string InstallCertOptionName = "--install-cert";
     private Option<bool?> _installCertOption;
+    internal static readonly string UrlsToWatchOptionName = "--urls-to-watch";
     private static Option<IEnumerable<string>?>? _urlsToWatchOption;
 
     private static bool _configFileResolved = false;
@@ -178,11 +189,11 @@ internal class ProxyHost
 
     public ProxyHost()
     {
-        _portOption = new Option<int?>("--port", "The port for the proxy to listen on");
+        _portOption = new Option<int?>(PortOptionName, "The port for the proxy to listen on");
         _portOption.AddAlias("-p");
         _portOption.ArgumentHelpName = "port";
 
-        _ipAddressOption = new Option<string?>("--ip-address", "The IP address for the proxy to bind to")
+        _ipAddressOption = new Option<string?>(IpAddressOptionName, "The IP address for the proxy to bind to")
         {
             ArgumentHelpName = "ipAddress"
         };
@@ -194,17 +205,21 @@ internal class ProxyHost
             }
         });
 
-        _recordOption = new Option<bool?>("--record", "Use this option to record all request logs");
+        _recordOption = new Option<bool?>(RecordOptionName, "Use this option to record all request logs");
 
-        _watchPidsOption = new Option<IEnumerable<int>?>("--watch-pids", "The IDs of processes to watch for requests");
-        _watchPidsOption.ArgumentHelpName = "pids";
-        _watchPidsOption.AllowMultipleArgumentsPerToken = true;
+        _watchPidsOption = new Option<IEnumerable<int>?>(WatchPidsOptionName, "The IDs of processes to watch for requests")
+        {
+            ArgumentHelpName = "pids",
+            AllowMultipleArgumentsPerToken = true
+        };
 
-        _watchProcessNamesOption = new Option<IEnumerable<string>?>("--watch-process-names", "The names of processes to watch for requests");
-        _watchProcessNamesOption.ArgumentHelpName = "processNames";
-        _watchProcessNamesOption.AllowMultipleArgumentsPerToken = true;
+        _watchProcessNamesOption = new Option<IEnumerable<string>?>(WatchProcessNamesOptionName, "The names of processes to watch for requests")
+        {
+            ArgumentHelpName = "processNames",
+            AllowMultipleArgumentsPerToken = true
+        };
 
-        _rateOption = new Option<int?>("--failure-rate", "The percentage of chance that a request will fail");
+        _rateOption = new Option<int?>(RateOptionName, "The percentage of chance that a request will fail");
         _rateOption.AddAlias("-f");
         _rateOption.ArgumentHelpName = "failure rate";
         _rateOption.AddValidator((input) =>
@@ -216,12 +231,12 @@ internal class ProxyHost
             }
         });
 
-        _noFirstRunOption = new Option<bool?>("--no-first-run", "Skip the first run experience");
+        _noFirstRunOption = new Option<bool?>(NoFirstRunOptionName, "Skip the first run experience");
 
-        _asSystemProxyOption = new Option<bool?>("--as-system-proxy", "Set Dev Proxy as the system proxy");
+        _asSystemProxyOption = new Option<bool?>(AsSystemProxyOptionName, "Set Dev Proxy as the system proxy");
         _asSystemProxyOption.SetDefaultValue(true);
 
-        _installCertOption = new Option<bool?>("--install-cert", "Install self-signed certificate");
+        _installCertOption = new Option<bool?>(InstallCertOptionName, "Install self-signed certificate");
         _installCertOption.SetDefaultValue(true);
         _installCertOption.AddValidator((input) =>
         {
@@ -233,7 +248,7 @@ internal class ProxyHost
             }
         });
 
-        _urlsToWatchOption = new("--urls-to-watch", "The list of URLs to watch for requests")
+        _urlsToWatchOption = new(UrlsToWatchOptionName, "The list of URLs to watch for requests")
         {
             ArgumentHelpName = "urlsToWatch",
             AllowMultipleArgumentsPerToken = true,
@@ -287,6 +302,22 @@ internal class ProxyHost
         return command;
     }
 
-    public ProxyCommandHandler GetCommandHandler(PluginEvents pluginEvents, Option[] options, ISet<UrlToWatch> urlsToWatch, ILogger logger) => new ProxyCommandHandler(_portOption, _ipAddressOption, _logLevelOption!, _recordOption, _watchPidsOption, _watchProcessNamesOption, _rateOption, _noFirstRunOption, _asSystemProxyOption, _installCertOption, pluginEvents, options, urlsToWatch, logger);
+    public ProxyCommandHandler GetCommandHandler(PluginEvents pluginEvents, Option[] optionsFromPlugins, ISet<UrlToWatch> urlsToWatch, ILogger logger) => new ProxyCommandHandler(
+        pluginEvents,
+        new Option[] {
+            _portOption,
+            _ipAddressOption,
+            _logLevelOption!,
+            _recordOption,
+            _watchPidsOption,
+            _watchProcessNamesOption,
+            _rateOption,
+            _noFirstRunOption,
+            _asSystemProxyOption,
+            _installCertOption,
+        }.Concat(optionsFromPlugins).ToArray(),
+        urlsToWatch,
+        logger
+    );
 }
 


### PR DESCRIPTION
Refactors passing global options into root command handler so that we don't need to define each global option in multiple places.