### PR TITLE
Extends CrudApiPlugin to support Entra auth. Closes #556

### DIFF
--- a/dev-proxy-plugins/MockResponses/CrudApiDefinitionLoader.cs
+++ b/dev-proxy-plugins/MockResponses/CrudApiDefinitionLoader.cs
@@ -68,7 +68,7 @@ internal class CrudApiDefinitionLoader : IDisposable
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "An error has occurred while reading {apiFile}:", _configuration.ApiFile);
+            _logger.LogError(ex, "An error has occurred while reading {apiFile}", _configuration.ApiFile);
         }
     }
 

--- a/dev-proxy-plugins/MockResponses/CrudApiDefinitionLoader.cs
+++ b/dev-proxy-plugins/MockResponses/CrudApiDefinitionLoader.cs
@@ -37,6 +37,8 @@ internal class CrudApiDefinitionLoader : IDisposable
                     var apiDefinitionConfig = JsonSerializer.Deserialize<CrudApiConfiguration>(apiDefinitionString);
                     _configuration.BaseUrl = apiDefinitionConfig?.BaseUrl ?? string.Empty;
                     _configuration.DataFile = apiDefinitionConfig?.DataFile ?? string.Empty;
+                    _configuration.Auth = apiDefinitionConfig?.Auth ?? CrudApiAuthType.None;
+                    _configuration.EntraAuthConfig = apiDefinitionConfig?.EntraAuthConfig;
 
                     IEnumerable<CrudApiAction>? configResponses = apiDefinitionConfig?.Actions;
                     if (configResponses is not null)

--- a/dev-proxy-plugins/MockResponses/CrudApiPlugin.cs
+++ b/dev-proxy-plugins/MockResponses/CrudApiPlugin.cs
@@ -50,8 +50,8 @@ public class CrudApiEntraAuth
     public string[] Roles { get; set; } = Array.Empty<string>();
     [JsonPropertyName("validateLifetime")]
     public bool ValidateLifetime { get; set; } = false;
-    [JsonPropertyName("validateToken")]
-    public bool ValidateToken { get; set; } = false;
+    [JsonPropertyName("validateSigningKey")]
+    public bool ValidateSigningKey { get; set; } = false;
 }
 
 public class CrudApiAction
@@ -227,9 +227,9 @@ public class CrudApiPlugin : BaseProxyPlugin
             ValidateAudience = !string.IsNullOrEmpty(authConfig.Audience),
             ValidAudience = authConfig.Audience,
             ValidateLifetime = authConfig.ValidateLifetime,
-            ValidateIssuerSigningKey = authConfig.ValidateToken
+            ValidateIssuerSigningKey = authConfig.ValidateSigningKey
         };
-        if (!authConfig.ValidateToken)
+        if (!authConfig.ValidateSigningKey)
         {
             // suppress token validation
             validationParameters.SignatureValidator = delegate (string token, TokenValidationParameters parameters)

--- a/dev-proxy-plugins/MockResponses/CrudApiPlugin.cs
+++ b/dev-proxy-plugins/MockResponses/CrudApiPlugin.cs
@@ -12,6 +12,12 @@ using Titanium.Web.Proxy.Models;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Microsoft.Extensions.Logging;
+using System.IdentityModel.Tokens.Jwt;
+using System.Diagnostics;
+using Microsoft.IdentityModel.Tokens;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+using Microsoft.IdentityModel.Protocols;
+using System.Security.Claims;
 
 namespace Microsoft.DevProxy.Plugins.MockResponses;
 
@@ -26,6 +32,28 @@ public enum CrudApiActionType
     Delete
 }
 
+public enum CrudApiAuthType
+{
+    None,
+    Entra
+}
+
+public class CrudApiEntraAuth
+{
+    [JsonPropertyName("audience")]
+    public string Audience { get; set; } = string.Empty;
+    [JsonPropertyName("issuer")]
+    public string Issuer { get; set; } = string.Empty;
+    [JsonPropertyName("scopes")]
+    public string[] Scopes { get; set; } = Array.Empty<string>();
+    [JsonPropertyName("roles")]
+    public string[] Roles { get; set; } = Array.Empty<string>();
+    [JsonPropertyName("validateLifetime")]
+    public bool ValidateLifetime { get; set; } = false;
+    [JsonPropertyName("validateToken")]
+    public bool ValidateToken { get; set; } = false;
+}
+
 public class CrudApiAction
 {
     [JsonPropertyName("action")]
@@ -37,6 +65,11 @@ public class CrudApiAction
     public string? Method { get; set; }
     [JsonPropertyName("query")]
     public string Query { get; set; } = string.Empty;
+    [JsonPropertyName("auth")]
+    [System.Text.Json.Serialization.JsonConverter(typeof(JsonStringEnumConverter))]
+    public CrudApiAuthType Auth { get; set; } = CrudApiAuthType.None;
+    [JsonPropertyName("entraAuthConfig")]
+    public CrudApiEntraAuth? EntraAuthConfig { get; set; }
 }
 
 public class CrudApiConfiguration
@@ -49,6 +82,11 @@ public class CrudApiConfiguration
     public string DataFile { get; set; } = string.Empty;
     [JsonPropertyName("actions")]
     public IEnumerable<CrudApiAction> Actions { get; set; } = Array.Empty<CrudApiAction>();
+    [JsonPropertyName("auth")]
+    [System.Text.Json.Serialization.JsonConverter(typeof(JsonStringEnumConverter))]
+    public CrudApiAuthType Auth { get; set; } = CrudApiAuthType.None;
+    [JsonPropertyName("entraAuthConfig")]
+    public CrudApiEntraAuth? EntraAuthConfig { get; set; }
 }
 
 public class CrudApiPlugin : BaseProxyPlugin
@@ -58,8 +96,9 @@ public class CrudApiPlugin : BaseProxyPlugin
     public override string Name => nameof(CrudApiPlugin);
     private IProxyConfiguration? _proxyConfiguration;
     private JArray? _data;
+    private OpenIdConnectConfiguration? _openIdConnectConfiguration;
 
-    public override void Register(IPluginEvents pluginEvents,
+    public override async void Register(IPluginEvents pluginEvents,
                             IProxyContext context,
                             ISet<UrlToWatch> urlsToWatch,
                             IConfigurationSection? configSection = null)
@@ -77,7 +116,22 @@ public class CrudApiPlugin : BaseProxyPlugin
         _loader = new CrudApiDefinitionLoader(_logger!, _configuration);
         _loader?.InitApiDefinitionWatcher();
 
+        if (_configuration.Auth == CrudApiAuthType.Entra &&
+            _configuration.EntraAuthConfig is null)
+        {
+            _logger?.LogError("Entra auth is enabled but no configuration is provided. API will work anonymously.");
+            _configuration.Auth = CrudApiAuthType.None;
+        }
+
         LoadData();
+        await SetupOpenIdConnectConfiguration();
+    }
+
+    private async Task SetupOpenIdConnectConfiguration()
+    {
+        var retriever = new OpenIdConnectConfigurationRetriever();
+        var configurationManager = new ConfigurationManager<OpenIdConnectConfiguration>("https://login.microsoftonline.com/organizations/v2.0/.well-known/openid-configuration", retriever);
+        _openIdConnectConfiguration = await configurationManager.GetConfigurationAsync();
     }
 
     private void LoadData()
@@ -107,15 +161,141 @@ public class CrudApiPlugin : BaseProxyPlugin
 
         if (_urlsToWatch is not null && e.ShouldExecute(_urlsToWatch))
         {
+            if (!AuthorizeRequest(e))
+            {
+                SendUnauthorizedResponse(e.Session);
+                state.HasBeenSet = true;
+                return Task.CompletedTask;
+            }
+
             var actionAndParams = GetMatchingActionHandler(request);
             if (actionAndParams is not null)
             {
+                if (!AuthorizeRequest(e, actionAndParams.Item2))
+                {
+                    SendUnauthorizedResponse(e.Session);
+                    state.HasBeenSet = true;
+                    return Task.CompletedTask;
+                }
+
                 actionAndParams.Item1(e.Session, actionAndParams.Item2, actionAndParams.Item3);
                 state.HasBeenSet = true;
             }
         }
 
         return Task.CompletedTask;
+    }
+
+    private bool AuthorizeRequest(ProxyRequestArgs e, CrudApiAction? action = null)
+    {
+        var authType = action is null ? _configuration.Auth : action.Auth;
+        var authConfig = action is null ? _configuration.EntraAuthConfig : action.EntraAuthConfig;
+
+        if (authType == CrudApiAuthType.None)
+        {
+            if (action is null)
+            {
+                _logger?.LogDebug("No auth is required for this API.");
+            }
+            return true;
+        }
+
+        Debug.Assert(authConfig is not null, "EntraAuthConfig is null when auth is required.");
+
+        var token = e.Session.HttpClient.Request.Headers.FirstOrDefault(h => h.Name.Equals("Authorization", StringComparison.OrdinalIgnoreCase))?.Value;
+        // is there a token
+        if (string.IsNullOrEmpty(token))
+        {
+            _logger?.LogRequest(["401 Unauthorized", "No token found on the request."], MessageType.Failed, new LoggingContext(e.Session));
+            return false;
+        }
+
+        // does the token has a valid format
+        var tokenHeaderParts = token.Split(' ');
+        if (tokenHeaderParts.Length != 2 || tokenHeaderParts[0] != "Bearer")
+        {
+            _logger?.LogRequest(["401 Unauthorized", "The specified token is not a valid Bearer token."], MessageType.Failed, new LoggingContext(e.Session));
+            return false;
+        }
+
+        var handler = new JwtSecurityTokenHandler();
+        var validationParameters = new TokenValidationParameters
+        {
+            IssuerSigningKeys = _openIdConnectConfiguration?.SigningKeys,
+            ValidateIssuer = !string.IsNullOrEmpty(authConfig.Issuer),
+            ValidIssuer = authConfig.Issuer,
+            ValidateAudience = !string.IsNullOrEmpty(authConfig.Audience),
+            ValidAudience = authConfig.Audience,
+            ValidateLifetime = authConfig.ValidateLifetime,
+            ValidateIssuerSigningKey = authConfig.ValidateToken
+        };
+        if (!authConfig.ValidateToken)
+        {
+            // suppress token validation
+            validationParameters.SignatureValidator = delegate (string token, TokenValidationParameters parameters)
+            {
+                var jwt = new JwtSecurityToken(token);
+                return jwt;
+            };
+        }
+        SecurityToken validatedToken;
+        try
+        {
+            var claimsPrincipal = handler.ValidateToken(tokenHeaderParts[1], validationParameters, out validatedToken);
+
+            // does the token has valid roles/scopes
+            if (authConfig.Roles.Any())
+            {
+                var rolesFromTheToken = string.Join(' ', claimsPrincipal.Claims
+                    .Where(c => c.Type == ClaimTypes.Role)
+                    .Select(c => c.Value));
+
+                if (!authConfig.Roles.Any(r => HasPermission(r, rolesFromTheToken)))
+                {
+                    var rolesRequired = string.Join(", ", authConfig.Roles);
+
+                    _logger?.LogRequest(["401 Unauthorized", $"The specified token does not have the necessary role(s). Required one of: {rolesRequired}, found: {rolesFromTheToken}"], MessageType.Failed, new LoggingContext(e.Session));
+                    return false;
+                }
+            }
+            if (authConfig.Scopes.Any())
+            {
+                var scopesFromTheToken = string.Join(' ', claimsPrincipal.Claims
+                    .Where(c => c.Type == "http://schemas.microsoft.com/identity/claims/scope")
+                    .Select(c => c.Value));
+
+                if (!authConfig.Scopes.Any(s => HasPermission(s, scopesFromTheToken)))
+                {
+                    var scopesRequired = string.Join(", ", authConfig.Scopes);
+
+                    _logger?.LogRequest(["401 Unauthorized", $"The specified token does not have the necessary scope(s). Required one of: {scopesRequired}, found: {scopesFromTheToken}"], MessageType.Failed, new LoggingContext(e.Session));
+                    return false;
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogRequest(["401 Unauthorized", $"The specified token is not valid: {ex.Message}"], MessageType.Failed, new LoggingContext(e.Session));
+            return false;
+        }
+
+        return true;
+    }
+
+    private bool HasPermission(string permission, string permissionString)
+    {
+        if (string.IsNullOrEmpty(permissionString))
+        {
+            return false;
+        }
+
+        var permissions = permissionString.Split(' ');
+        return permissions.Contains(permission, StringComparer.OrdinalIgnoreCase);
+    }
+
+    private void SendUnauthorizedResponse(SessionEventArgs e)
+    {
+        SendJsonResponse("{\"error\":{\"message\":\"Unauthorized\"}}", HttpStatusCode.Unauthorized, e);
     }
 
     private void SendNotFoundResponse(SessionEventArgs e)

--- a/dev-proxy-plugins/MockResponses/CrudApiPlugin.cs
+++ b/dev-proxy-plugins/MockResponses/CrudApiPlugin.cs
@@ -129,9 +129,16 @@ public class CrudApiPlugin : BaseProxyPlugin
 
     private async Task SetupOpenIdConnectConfiguration()
     {
-        var retriever = new OpenIdConnectConfigurationRetriever();
-        var configurationManager = new ConfigurationManager<OpenIdConnectConfiguration>("https://login.microsoftonline.com/organizations/v2.0/.well-known/openid-configuration", retriever);
-        _openIdConnectConfiguration = await configurationManager.GetConfigurationAsync();
+        try
+        {
+            var retriever = new OpenIdConnectConfigurationRetriever();
+            var configurationManager = new ConfigurationManager<OpenIdConnectConfiguration>("https://login.microsoftonline.com/organizations/v2.0/.well-known/openid-configuration", retriever);
+            _openIdConnectConfiguration = await configurationManager.GetConfigurationAsync();
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogError($"An error has occurred while loading OpenIdConnectConfiguration:" + ex.Message);
+        }
     }
 
     private void LoadData()

--- a/dev-proxy-plugins/MockResponses/CrudApiPlugin.cs
+++ b/dev-proxy-plugins/MockResponses/CrudApiPlugin.cs
@@ -137,7 +137,7 @@ public class CrudApiPlugin : BaseProxyPlugin
         }
         catch (Exception ex)
         {
-            _logger?.LogError($"An error has occurred while loading OpenIdConnectConfiguration:" + ex.Message);
+            _logger?.LogError(ex, "An error has occurred while loading OpenIdConnectConfiguration");
         }
     }
 
@@ -157,7 +157,7 @@ public class CrudApiPlugin : BaseProxyPlugin
         }
         catch (Exception ex)
         {
-            _logger?.LogError(ex, "An error has occured while reading {configFile}", _configuration.DataFile);
+            _logger?.LogError(ex, "An error has occurred while reading {configFile}", _configuration.DataFile);
         }
     }
 

--- a/dev-proxy-plugins/MockResponses/CrudApiPlugin.cs
+++ b/dev-proxy-plugins/MockResponses/CrudApiPlugin.cs
@@ -257,6 +257,8 @@ public class CrudApiPlugin : BaseProxyPlugin
                     _logger?.LogRequest(["401 Unauthorized", $"The specified token does not have the necessary role(s). Required one of: {rolesRequired}, found: {rolesFromTheToken}"], MessageType.Failed, new LoggingContext(e.Session));
                     return false;
                 }
+
+                return true;
             }
             if (authConfig.Scopes.Any())
             {
@@ -271,6 +273,8 @@ public class CrudApiPlugin : BaseProxyPlugin
                     _logger?.LogRequest(["401 Unauthorized", $"The specified token does not have the necessary scope(s). Required one of: {scopesRequired}, found: {scopesFromTheToken}"], MessageType.Failed, new LoggingContext(e.Session));
                     return false;
                 }
+
+                return true;
             }
         }
         catch (Exception ex)

--- a/dev-proxy-plugins/dev-proxy-plugins.csproj
+++ b/dev-proxy-plugins/dev-proxy-plugins.csproj
@@ -21,6 +21,10 @@
       <Private>false</Private>
       <ExcludeAssets>runtime</ExcludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="7.3.1">
+      <Private>false</Private>
+      <ExcludeAssets>runtime</ExcludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.OpenApi" Version="1.6.13">
       <Private>false</Private>
       <ExcludeAssets>runtime</ExcludeAssets>

--- a/dev-proxy/dev-proxy.csproj
+++ b/dev-proxy/dev-proxy.csproj
@@ -33,6 +33,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
+    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="7.3.1" />
     <PackageReference Include="Microsoft.OpenApi.Readers" Version="1.6.13" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />

--- a/schemas/v0.15.0/crudapiplugin.schema.json
+++ b/schemas/v0.15.0/crudapiplugin.schema.json
@@ -5,7 +5,7 @@
   "type": "object",
   "properties": {
     "$schema": {
-    	"type":"string"
+      "type": "string"
     },
     "baseUrl": {
       "type": "string"
@@ -47,16 +47,11 @@
             ]
           },
           "auth": {
-            "type": "object",
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "None",
-                  "Entra"
-                ]
-              }
-            }
+            "type": "string",
+            "enum": [
+              "none",
+              "entra"
+            ]
           },
           "entraAuthConfig": {
             "type": "object",
@@ -95,16 +90,11 @@
       }
     },
     "auth": {
-      "type": "object",
-      "properties": {
-        "type": {
-          "type": "string",
-          "enum": [
-            "None",
-            "Entra"
-          ]
-        }
-      }
+      "type": "string",
+      "enum": [
+        "none",
+        "entra"
+      ]
     },
     "entraAuthConfig": {
       "type": "object",

--- a/schemas/v0.15.0/crudapiplugin.schema.json
+++ b/schemas/v0.15.0/crudapiplugin.schema.json
@@ -45,12 +45,94 @@
               "PATCH",
               "DELETE"
             ]
+          },
+          "auth": {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "None",
+                  "Entra"
+                ]
+              }
+            }
+          },
+          "entraAuthConfig": {
+            "type": "object",
+            "properties": {
+              "audience": {
+                "type": "string"
+              },
+              "issuer": {
+                "type": "string"
+              },
+              "scopes": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "roles": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "validateLifetime": {
+                "type": "boolean"
+              },
+              "validateToken": {
+                "type": "boolean"
+              }
+            }
           }
         },
         "required": [
           "action"
         ],
         "additionalProperties": false
+      }
+    },
+    "auth": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "None",
+            "Entra"
+          ]
+        }
+      }
+    },
+    "entraAuthConfig": {
+      "type": "object",
+      "properties": {
+        "audience": {
+          "type": "string"
+        },
+        "issuer": {
+          "type": "string"
+        },
+        "scopes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "roles": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "validateLifetime": {
+          "type": "boolean"
+        },
+        "validateToken": {
+          "type": "boolean"
+        }
       }
     }
   },

--- a/schemas/v0.15.0/crudapiplugin.schema.json
+++ b/schemas/v0.15.0/crudapiplugin.schema.json
@@ -82,7 +82,7 @@
               "validateLifetime": {
                 "type": "boolean"
               },
-              "validateToken": {
+              "validateSigningKey": {
                 "type": "boolean"
               }
             }
@@ -130,7 +130,7 @@
         "validateLifetime": {
           "type": "boolean"
         },
-        "validateToken": {
+        "validateSigningKey": {
           "type": "boolean"
         }
       }


### PR DESCRIPTION
Extends CrudApiPlugin to support Entra auth. Closes #556

To test, you can use the [northwind db sample](https://adoption.microsoft.com/sample-solution-gallery/sample/pnp-devproxy-northwinddb)

Update orders-api.json for example to:

```json
{
  "$schema": "https://raw.githubusercontent.com/microsoft/dev-proxy/main/schemas/v1.0/crudapiplugin.schema.json",
  "baseUrl": "https://api.northwind.com/orders",
  "auth": "Entra",
  "entraAuthConfig": {
    "validateSigningKey": true
  },
  "dataFile": "orders-data.json",
  "actions": [
    {
      "action": "getAll"
    },
    {
      "action": "getOne",
      "url": "/{order-id}",
      "query": "$.[?(@.OrderID == {order-id})]"
    },
    {
      "action": "create"
    },
    {
      "action": "merge",
      "url": "/{order-id}",
      "query": "$.[?(@.OrderID == {order-id})]"
    },
    {
      "action": "delete",
      "url": "/{order-id}",
      "query": "$.[?(@.OrderID == {order-id})]"
    }
  ]
}
```

Call the API from curl by passing a valid Entra token:

```bash
curl -ix http://127.0.0.1:8000 -H "authorization:Bearer eyJ0eXAiOiJKV1QiLCJhbG...." https://api.northwind.com/orders
```

In `entraAuthConfig` you can specify several options as to what parts of the token you want the API to validate:

- `audience`: set to the audience string from the token to validate the audience, eg. `https://manage.office.com`
- `issuer`: set to the ID of the IdP that issued the token, eg. `https://sts.windows.net/06fde681-d710-4b73-8bc6-90585c5630e9/`
- `scopes`: set to define the list of scopes for all actions. The token must have at least one of the scopes
- `roles`: set to define the list of roles for all actions. The token must have at least of the roles
- `validateLifetime`: set to `true` for the API to validate if the token hasn't expired
- `validateSigningKey`: set to `true` for the API to validate if the token signature is valid. Requires you to specify a valid and untempered with token issued by Entra

All these properties can be overriden on each action, which allows you to for example specify unique scopes/roles for each action:

```json
{
  "$schema": "https://raw.githubusercontent.com/microsoft/dev-proxy/main/schemas/v1.0/crudapiplugin.schema.json",
  "baseUrl": "https://api.northwind.com/orders",
  "auth": "Entra",
  "entraAuthConfig": {
    "validateSigningKey": true
  },
  "dataFile": "orders-data.json",
  "actions": [
    {
      "action": "getAll",
      "auth": "Entra",
      "entraAuthConfig": {
        "scopes": [
          "orders.read"
        ]
      }
    },
    {
      "action": "getOne",
      "url": "/{order-id}",
      "query": "$.[?(@.OrderID == {order-id})]",
      "auth": "Entra",
      "entraAuthConfig": {
        "scopes": [
          "orders.read"
        ]
      }
    },
    {
      "action": "create",
      "auth": "Entra",
      "entraAuthConfig": {
        "scopes": [
          "orders.write"
        ]
      }
    },
    {
      "action": "merge",
      "url": "/{order-id}",
      "query": "$.[?(@.OrderID == {order-id})]",
      "auth": "Entra",
      "entraAuthConfig": {
        "scopes": [
          "orders.write"
        ]
      }
    },
    {
      "action": "delete",
      "url": "/{order-id}",
      "query": "$.[?(@.OrderID == {order-id})]",
      "auth": "Entra",
      "entraAuthConfig": {
        "scopes": [
          "orders.write"
        ]
      }
    }
  ]
}
```