### PR TITLE
Fixes generating OpenAPI specs with duplicate response headers. Closes #571

### DIFF
--- a/dev-proxy-plugins/RequestLogs/OpenApiSpecGeneratorPlugin.cs
+++ b/dev-proxy-plugins/RequestLogs/OpenApiSpecGeneratorPlugin.cs
@@ -583,6 +583,12 @@ public class OpenApiSpecGeneratorPlugin : BaseProxyPlugin
                     continue;
                 }
 
+                if (openApiResponse.Headers.ContainsKey(header.Name))
+                {
+                    _logger?.LogDebug("    Header {headerName} already exists in response", header.Name);
+                    continue;
+                }
+
                 openApiResponse.Headers.Add(header.Name, new OpenApiHeader
                 {
                     Schema = new OpenApiSchema { Type = "string" }


### PR DESCRIPTION
Fixes generating OpenAPI specs with duplicate response headers. Closes #571

To test, stand up a custom API that returns responses with duplicate headers, like:

```js
const express = require('express');
const app = express();
const PORT = 3000;

// Define a GET endpoint
app.get('/', (req, res) => {
  res.append('X-Custom-Header', 'HeaderValue');
  res.append('X-Custom-Header', 'HeaderValue2');

  res.send('Hello, World!');
});

// Start the server
app.listen(PORT, () => {
  console.log(`Server is running on http://localhost:${PORT}`);
});%
```