### PR TITLE
Added configuring for HTTP proxy

### DIFF
--- a/dev-proxy/ProxyEngine.cs
+++ b/dev-proxy/ProxyEngine.cs
@@ -125,6 +125,7 @@ public class ProxyEngine
         {
             if (RunTime.IsWindows)
             {
+                _proxyServer.SetAsSystemHttpProxy(_explicitEndPoint);
                 _proxyServer.SetAsSystemHttpsProxy(_explicitEndPoint);
             }
             else if (RunTime.IsMac)

--- a/dev-proxy/toggle-proxy.sh
+++ b/dev-proxy/toggle-proxy.sh
@@ -9,10 +9,12 @@ network_services=$(networksetup -listallnetworkservices | tail -n +2)
 if [[ "$toggle" == "on" ]]; then
   while IFS= read -r service; do
     networksetup -setsecurewebproxy "$service" $ip $port
+    networksetup -setwebproxy "$service" $ip $port
   done <<<"$network_services"
 elif [[ "$toggle" == "off" ]]; then
   while IFS= read -r service; do
     networksetup -setsecurewebproxystate "$service" off
+    networksetup -setwebproxystate "$service" off
   done <<<"$network_services"
 else
   echo "Set the first argument to on or off."


### PR DESCRIPTION
Brought back the setting of HTTP proxy on Windows, that was removed in ticket #444.
Extended the toggle-proxy.sh script so that it also enables/disabled HTTP proxy on macOS