### PR TITLE
Show hotkeys log on proxy start and after clear screen

### DIFF
--- a/dev-proxy/ProxyEngine.cs
+++ b/dev-proxy/ProxyEngine.cs
@@ -580,7 +580,7 @@ public class ProxyEngine
     
     private void LogHotkeysInstructions()
     {
-        _logger.LogInformation("Hotkeys: (r)ecord, (s)top recording, (c)lear screen");
-        _logger.LogInformation("Press CTRL+C to stop Dev Proxy\r\n");
+        Console.WriteLine("Hotkeys: (r)ecord, (s)top recording, (c)lear screen");
+        Console.WriteLine("Press CTRL+C to stop Dev Proxy");
     }
 }

--- a/dev-proxy/ProxyEngine.cs
+++ b/dev-proxy/ProxyEngine.cs
@@ -150,7 +150,7 @@ public class ProxyEngine
             _logger.LogInformation("Configure your application to use this proxy's port and address");
         }
 
-        LogHotkeysInstructions();
+        PrintHotkeys();
         Console.CancelKeyPress += Console_CancelKeyPress;
 
         if (_config.Record)
@@ -237,7 +237,7 @@ public class ProxyEngine
             if (key == ConsoleKey.C)
             {
                 Console.Clear();
-                LogHotkeysInstructions();
+                PrintHotkeys();
             }
             if (key == ConsoleKey.W)
             {
@@ -590,9 +590,11 @@ public class ProxyEngine
         return Task.CompletedTask;
     }
     
-    private void LogHotkeysInstructions()
+    private void PrintHotkeys()
     {
+        Console.WriteLine("");
         Console.WriteLine("Hotkeys: (r)ecord, (s)top recording, (c)lear screen");
         Console.WriteLine("Press CTRL+C to stop Dev Proxy");
+        Console.WriteLine("");
     }
 }

--- a/dev-proxy/ProxyEngine.cs
+++ b/dev-proxy/ProxyEngine.cs
@@ -142,7 +142,7 @@ public class ProxyEngine
             _logger.LogInformation("Configure your application to use this proxy's port and address");
         }
 
-        _logger.LogInformation("Press CTRL+C to stop Dev Proxy\r\n");
+        LogHotkeysInstructions();
         Console.CancelKeyPress += Console_CancelKeyPress;
 
         if (_config.Record)
@@ -229,8 +229,7 @@ public class ProxyEngine
             if (key == ConsoleKey.C)
             {
                 Console.Clear();
-                Console.WriteLine("Press CTRL+C to stop Dev Proxy");
-                Console.WriteLine("");
+                LogHotkeysInstructions();
             }
         } while (key != ConsoleKey.Escape);
     }
@@ -577,5 +576,11 @@ public class ProxyEngine
     {
         // set e.clientCertificate to override
         return Task.CompletedTask;
+    }
+    
+    private void LogHotkeysInstructions()
+    {
+        _logger.LogInformation("Hotkeys: (r)ecord, (s)top recording, (c)lear screen");
+        _logger.LogInformation("Press CTRL+C to stop Dev Proxy\r\n");
     }
 }

--- a/dev-proxy/ProxyEngine.cs
+++ b/dev-proxy/ProxyEngine.cs
@@ -592,7 +592,6 @@ public class ProxyEngine
     
     private void PrintHotkeys()
     {
-        Console.WriteLine("");
         Console.WriteLine("Hotkeys: (r)ecord, (s)top recording, (c)lear screen");
         Console.WriteLine("Press CTRL+C to stop Dev Proxy");
         Console.WriteLine("");


### PR DESCRIPTION
It should close #585  

I extracted common method for hotkeys instructions logging
Also I use `_logger` instance to log instructions in `ReadKeys` method instead of `Console.WriteLine` (as far as I understand `_logger` is a wrapper of `Console`)