### PR TITLE
Adds support for simulating Graph connector TAC notifications. Closes #594

### DIFF
--- a/dev-proxy-abstractions/IProxyLogger.cs
+++ b/dev-proxy-abstractions/IProxyLogger.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
-using System.Runtime.Serialization;
 using Titanium.Web.Proxy.EventArguments;
 using Microsoft.Extensions.Logging;
 
@@ -33,4 +32,5 @@ public interface IProxyLogger : ICloneable, ILogger
 {
     public LogLevel LogLevel { get; set; }
     public void LogRequest(string[] message, MessageType messageType, LoggingContext? context = null);
+    public void LogRequest(string[] message, MessageType messageType, string method, string url);
 }

--- a/dev-proxy-abstractions/JsonExtensions.cs
+++ b/dev-proxy-abstractions/JsonExtensions.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text.Json;
+
+namespace Microsoft.DevProxy.Abstractions;
+
+// from https://stackoverflow.com/questions/61553962/getting-nested-properties-with-system-text-json
+public static partial class JsonExtensions
+{
+    public static JsonElement? Get(this JsonElement element, string name) => 
+        element.ValueKind != JsonValueKind.Null && element.ValueKind != JsonValueKind.Undefined && element.TryGetProperty(name, out var value) 
+            ? value : (JsonElement?)null;
+    
+    public static JsonElement? Get(this JsonElement element, int index)
+    {
+        if (element.ValueKind == JsonValueKind.Null || element.ValueKind == JsonValueKind.Undefined)
+            return null;
+        // Throw if index < 0
+        return index < element.GetArrayLength() ? element[index] : null;
+    }
+}

--- a/dev-proxy-abstractions/MockRequest.cs
+++ b/dev-proxy-abstractions/MockRequest.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text.Json.Serialization;
+
+namespace Microsoft.DevProxy.Abstractions;
+
+public class MockRequest
+{
+    [JsonPropertyName("url")]
+    public string Url { get; set; } = string.Empty;
+    [JsonPropertyName("method")]
+    public string Method { get; set; } = "GET";
+    [JsonPropertyName("body")]
+    public dynamic? Body { get; set; }
+    [JsonPropertyName("headers")]
+    public List<MockRequestHeader>? Headers { get; set; }
+}
+
+public class MockRequestHeader
+{
+    [JsonPropertyName("name")]
+    public string Name { get; set; } = string.Empty;
+    [JsonPropertyName("value")]
+    public string Value { get; set; } = string.Empty;
+
+    public MockRequestHeader()
+    {
+    }
+
+    public MockRequestHeader(string name, string value)
+    {
+        Name = name;
+        Value = value;
+    }
+}

--- a/dev-proxy-abstractions/PluginEvents.cs
+++ b/dev-proxy-abstractions/PluginEvents.cs
@@ -3,6 +3,7 @@
 
 using System.CommandLine;
 using System.CommandLine.Invocation;
+using System.Security.Cryptography.X509Certificates;
 using Titanium.Web.Proxy.EventArguments;
 using Titanium.Web.Proxy.Http;
 
@@ -12,6 +13,7 @@ public interface IProxyContext
 {
     IProxyConfiguration Configuration { get; }
     IProxyLogger Logger { get; }
+    X509Certificate2? Certificate { get; }
 }
 
 public class ThrottlerInfo
@@ -182,6 +184,10 @@ public interface IPluginEvents
     /// Raised after recording request logs has stopped.
     /// </summary>
     event AsyncEventHandler<RecordingArgs>? AfterRecordingStop;
+    /// <summary>
+    /// Raised when user requested issuing mock requests.
+    /// </summary>
+    event AsyncEventHandler<EventArgs>? MockRequest;
 }
 
 public class PluginEvents : IPluginEvents
@@ -200,6 +206,7 @@ public class PluginEvents : IPluginEvents
     public event EventHandler<RequestLogArgs>? AfterRequestLog;
     /// <inheritdoc />
     public event AsyncEventHandler<RecordingArgs>? AfterRecordingStop;
+    public event AsyncEventHandler<EventArgs>? MockRequest;
 
     public void RaiseInit(InitArgs args)
     {
@@ -245,6 +252,14 @@ public class PluginEvents : IPluginEvents
         if (AfterRecordingStop is not null)
         {
             await AfterRecordingStop.InvokeAsync(this, args, null);
+        }
+    }
+
+    public async Task RaiseMockRequest(EventArgs args)
+    {
+        if (MockRequest is not null)
+        {
+            await MockRequest.InvokeAsync(this, args, null);
         }
     }
 }

--- a/dev-proxy-plugins/Behavior/RateLimitingCustomResponseLoader.cs
+++ b/dev-proxy-plugins/Behavior/RateLimitingCustomResponseLoader.cs
@@ -3,7 +3,7 @@
 
 using Microsoft.Extensions.Logging;
 using Microsoft.DevProxy.Abstractions;
-using Microsoft.DevProxy.Plugins.MockResponses;
+using Microsoft.DevProxy.Plugins.Mocks;
 using System.Text.Json;
 
 namespace Microsoft.DevProxy.Plugins.Behavior;

--- a/dev-proxy-plugins/Mocks/CrudApiDefinitionLoader.cs
+++ b/dev-proxy-plugins/Mocks/CrudApiDefinitionLoader.cs
@@ -5,7 +5,7 @@ using Microsoft.DevProxy.Abstractions;
 using Microsoft.Extensions.Logging;
 using System.Text.Json;
 
-namespace Microsoft.DevProxy.Plugins.MockResponses;
+namespace Microsoft.DevProxy.Plugins.Mocks;
 
 internal class CrudApiDefinitionLoader : IDisposable
 {

--- a/dev-proxy-plugins/Mocks/CrudApiPlugin.cs
+++ b/dev-proxy-plugins/Mocks/CrudApiPlugin.cs
@@ -19,7 +19,7 @@ using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 using Microsoft.IdentityModel.Protocols;
 using System.Security.Claims;
 
-namespace Microsoft.DevProxy.Plugins.MockResponses;
+namespace Microsoft.DevProxy.Plugins.Mocks;
 
 public enum CrudApiActionType
 {

--- a/dev-proxy-plugins/Mocks/GraphConnectorNotificationPlugin.cs
+++ b/dev-proxy-plugins/Mocks/GraphConnectorNotificationPlugin.cs
@@ -1,0 +1,194 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.IdentityModel.Tokens.Jwt;
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.DevProxy.Abstractions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Microsoft.IdentityModel.Tokens;
+using Titanium.Web.Proxy.EventArguments;
+
+namespace Microsoft.DevProxy.Plugins.Mocks;
+
+public class GraphConnectorNotificationConfiguration : MockRequestConfiguration
+{
+    [JsonPropertyName("audience")]
+    public string? Audience { get; set; }
+    [JsonPropertyName("tenant")]
+    public string? Tenant { get; set; }
+}
+
+public class GraphConnectorNotificationPlugin : MockRequestPlugin
+{
+    private string? _ticket = null;
+    private IProxyContext? _context;
+    private GraphConnectorNotificationConfiguration _graphConnectorConfiguration = new();
+
+    public override string Name => nameof(GraphConnectorNotificationPlugin);
+
+    public override void Register(IPluginEvents pluginEvents,
+                            IProxyContext context,
+                            ISet<UrlToWatch> urlsToWatch,
+                            IConfigurationSection? configSection = null)
+    {
+        _context = context;
+
+        base.Register(pluginEvents, context, urlsToWatch, configSection);
+        configSection?.Bind(_graphConnectorConfiguration);
+        _graphConnectorConfiguration.MockFile = _configuration.MockFile;
+        _graphConnectorConfiguration.Request = _configuration.Request;
+        
+        pluginEvents.BeforeRequest += OnBeforeRequest;
+    }
+
+    private Task OnBeforeRequest(object sender, ProxyRequestArgs e)
+    {
+        if (!ProxyUtils.IsGraphRequest(e.Session.HttpClient.Request))
+        {
+            return Task.CompletedTask;
+        }
+
+        VerifyTicket(e.Session);
+        return Task.CompletedTask;
+    }
+
+    private void VerifyTicket(SessionEventArgs session)
+    {
+        if (_ticket is null)
+        {
+            return;
+        }
+
+        var request = session.HttpClient.Request;
+
+        if (request.Method != "POST" && request.Method != "DELETE")
+        {
+            return;
+        }
+
+        if ((request.Method == "POST" &&
+            !request.RequestUri.AbsolutePath.EndsWith("/external/connections", StringComparison.OrdinalIgnoreCase)) ||
+            (request.Method == "DELETE" &&
+            !request.RequestUri.AbsolutePath.Contains("/external/connections/", StringComparison.OrdinalIgnoreCase)))
+        {
+            return;
+        }
+
+        var ticketFromHeader = request.Headers.FirstOrDefault(h => h.Name.Equals("GraphConnectors-Ticket", StringComparison.OrdinalIgnoreCase))?.Value;
+        if (ticketFromHeader is null)
+        {
+            _logger?.LogRequest(["No ticket header found in the Graph connector notification"], MessageType.Failed, new LoggingContext(session));
+            return;
+        }
+
+        if (ticketFromHeader != _ticket)
+        {
+            _logger?.LogRequest([$"Ticket on the request does not match the expected ticket. Expected: {_ticket}. Request: {ticketFromHeader}"], MessageType.Failed, new LoggingContext(session));
+        }
+    }
+
+    protected override async Task OnMockRequest(object sender, EventArgs e)
+    {
+        if (_configuration.Request is null)
+        {
+            _logger?.LogDebug("No mock request is configured. Skipping.");
+            return;
+        }
+
+        using (var httpClient = new HttpClient())
+        {
+            var requestMessage = GetRequestMessage();
+            if (requestMessage.Content is null)
+            {
+                _logger?.LogError("No body found in the mock request. Skipping.");
+                return;
+            }
+            var requestBody = await requestMessage.Content.ReadAsStringAsync();
+            requestBody = requestBody.Replace("@dynamic.validationToken", GetJwtToken());
+            requestMessage.Content = new StringContent(requestBody, Encoding.UTF8, "application/json");
+            LoadTicket();
+
+            try
+            {
+                _logger?.LogRequest(["Sending Graph connector notification"], MessageType.Mocked, _configuration.Request.Method, _configuration.Request.Url);
+
+                var response = await httpClient.SendAsync(requestMessage);
+
+                if (response.StatusCode != HttpStatusCode.Accepted)
+                {
+                    _logger?.LogRequest([$"Incorrect response status code {(int)response.StatusCode} {response.StatusCode}. Expected: 202 Accepted"], MessageType.Failed, _configuration.Request.Method, _configuration.Request.Url);
+                }
+
+                if (response.Content is not null)
+                {
+                    var content = await response.Content.ReadAsStringAsync();
+                    if (!string.IsNullOrEmpty(content))
+                    {
+                        _logger?.LogRequest(["Received response body while empty response expected"], MessageType.Failed, _configuration.Request.Method, _configuration.Request.Url);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger?.LogError(ex, "An error has occurred while sending the Graph connector notification to {url}", _configuration.Request.Url);
+            }
+        }
+    }
+
+    private string GetJwtToken()
+    {
+        var signingCredentials = new X509SigningCredentials(_context?.Certificate, SecurityAlgorithms.RsaSha256);
+
+        var tokenHandler = new JwtSecurityTokenHandler();
+        var tokenDescriptor = new SecurityTokenDescriptor
+        {
+            Claims = new Dictionary<string, object>
+            {
+                { "scp", "user_impersonation" },
+                { "sub", "l3_roISQU222bULS9yi2k0XpqpOiMz5H3ZACo1GeXA" },
+                // Graph Connector Service
+                { "appid", "56c1da01-2129-48f7-9355-af6d59d42766" }
+            },
+            Expires = DateTime.UtcNow.AddMinutes(60),
+            Issuer = $"https://sts.windows.net/{_graphConnectorConfiguration.Tenant}/",
+            Audience = _graphConnectorConfiguration.Audience,
+            SigningCredentials = signingCredentials
+        };
+
+        var token = tokenHandler.CreateToken(tokenDescriptor);
+        return tokenHandler.WriteToken(token);
+    }
+
+    private void LoadTicket()
+    {
+        if (_ticket is not null)
+        {
+            return;
+        }
+
+        if (_configuration.Request?.Body is null)
+        {
+            _logger?.LogWarning("No body found in the Graph connector notification. Ticket will not be loaded.");
+            return;
+        }
+
+        try
+        {
+            var body = (JsonElement)_configuration.Request.Body;
+            _ticket = body.Get("value")?.Get(0)?.Get("resourceData")?.Get("connectorsTicket")?.GetString();
+
+            if (string.IsNullOrEmpty(_ticket))
+            {
+                _logger?.LogError("No ticket found in the Graph connector notification body");
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogError(ex, "An error has occurred while reading the ticket from the Graph connector notification body");
+        }
+    }
+}

--- a/dev-proxy-plugins/Mocks/GraphMockResponsePlugin.cs
+++ b/dev-proxy-plugins/Mocks/GraphMockResponsePlugin.cs
@@ -9,7 +9,7 @@ using Microsoft.DevProxy.Plugins.Behavior;
 using Microsoft.Extensions.Logging;
 using Titanium.Web.Proxy.Models;
 
-namespace Microsoft.DevProxy.Plugins.MockResponses;
+namespace Microsoft.DevProxy.Plugins.Mocks;
 
 public class GraphMockResponsePlugin : MockResponsePlugin
 {

--- a/dev-proxy-plugins/Mocks/MockRequestLoader.cs
+++ b/dev-proxy-plugins/Mocks/MockRequestLoader.cs
@@ -1,0 +1,97 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.DevProxy.Abstractions;
+using Microsoft.Extensions.Logging;
+using System.Text.Json;
+
+namespace Microsoft.DevProxy.Plugins.Mocks;
+
+internal class MockRequestLoader : IDisposable
+{
+    private readonly IProxyLogger _logger;
+    private readonly MockRequestConfiguration _configuration;
+
+    public MockRequestLoader(IProxyLogger logger, MockRequestConfiguration configuration)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+    }
+
+    private string _requestFilePath => Path.Combine(Directory.GetCurrentDirectory(), _configuration.MockFile);
+    private FileSystemWatcher? _watcher;
+
+    public void LoadRequest()
+    {
+        if (!File.Exists(_requestFilePath))
+        {
+            _logger.LogWarning("File {configurationFile} not found. No mocks request will be issued", _configuration.MockFile);
+            _configuration.Request = null;
+            return;
+        }
+
+        try
+        {
+            using (FileStream stream = new FileStream(_requestFilePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
+            {
+                using (StreamReader reader = new StreamReader(stream))
+                {
+                    var requestString = reader.ReadToEnd();
+                    var requestConfig = JsonSerializer.Deserialize<MockRequestConfiguration>(requestString);
+                    var configRequest = requestConfig?.Request;
+                    if (configRequest is not null)
+                    {
+                        _configuration.Request = configRequest;
+                        _logger.LogInformation("Mock request to url {url} loaded from {mockFile}", _configuration.Request.Url, _configuration.MockFile);
+                    }
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "An error has occurred while reading {configurationFile}:", _configuration.MockFile);
+        }
+    }
+
+    public void InitResponsesWatcher()
+    {
+        if (_watcher is not null)
+        {
+            return;
+        }
+
+        string path = Path.GetDirectoryName(_requestFilePath) ?? throw new InvalidOperationException($"{_requestFilePath} is an invalid path");
+        if (!File.Exists(_requestFilePath))
+        {
+            _logger.LogWarning("File {configurationFile} not found. No mock request will be issued", _configuration.MockFile);
+            _configuration.Request = null;
+            return;
+        }
+
+        _watcher = new FileSystemWatcher(Path.GetFullPath(path))
+        {
+            NotifyFilter = NotifyFilters.CreationTime
+                             | NotifyFilters.FileName
+                             | NotifyFilters.LastWrite
+                             | NotifyFilters.Size,
+            Filter = Path.GetFileName(_requestFilePath)
+        };
+        _watcher.Changed += RequestFile_Changed;
+        _watcher.Created += RequestFile_Changed;
+        _watcher.Deleted += RequestFile_Changed;
+        _watcher.Renamed += RequestFile_Changed;
+        _watcher.EnableRaisingEvents = true;
+
+        LoadRequest();
+    }
+
+    private void RequestFile_Changed(object sender, FileSystemEventArgs e)
+    {
+        LoadRequest();
+    }
+
+    public void Dispose()
+    {
+        _watcher?.Dispose();
+    }
+}

--- a/dev-proxy-plugins/Mocks/MockRequestPlugin.cs
+++ b/dev-proxy-plugins/Mocks/MockRequestPlugin.cs
@@ -1,0 +1,117 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Diagnostics;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.DevProxy.Abstractions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.DevProxy.Plugins.Mocks;
+
+public class MockRequestConfiguration
+{
+    [JsonIgnore]
+    public string MockFile { get; set; } = "mock-request.json";
+    [JsonPropertyName("request")]
+    public MockRequest? Request { get; set; }
+}
+
+public class MockRequestPlugin : BaseProxyPlugin
+{
+    protected MockRequestConfiguration _configuration = new();
+    private MockRequestLoader? _loader = null;
+
+    public override string Name => nameof(MockRequestPlugin);
+
+    public override void Register(IPluginEvents pluginEvents,
+                            IProxyContext context,
+                            ISet<UrlToWatch> urlsToWatch,
+                            IConfigurationSection? configSection = null)
+    {
+        base.Register(pluginEvents, context, urlsToWatch, configSection);
+
+        configSection?.Bind(_configuration);
+        _loader = new MockRequestLoader(_logger!, _configuration);
+
+        pluginEvents.MockRequest += OnMockRequest;
+
+        // make the mock file path relative to the configuration file
+        _configuration.MockFile = Path.GetFullPath(ProxyUtils.ReplacePathTokens(_configuration.MockFile), Path.GetDirectoryName(context.Configuration?.ConfigFile ?? string.Empty) ?? string.Empty);
+
+        // load the request from the configured mock file
+        _loader.InitResponsesWatcher();
+    }
+
+    protected HttpRequestMessage GetRequestMessage()
+    {
+        Debug.Assert(_configuration.Request is not null, "The mock request is not configured");
+
+        _logger?.LogDebug("Preparing mock {method} request to {url}", _configuration.Request.Method, _configuration.Request.Url);
+        var requestMessage = new HttpRequestMessage
+        {
+            RequestUri = new Uri(_configuration.Request.Url),
+            Method = new HttpMethod(_configuration.Request.Method)
+        };
+
+        var contentType = "";
+        if (_configuration.Request.Headers is not null)
+        {
+            _logger?.LogDebug("Adding headers to the mock request");
+
+            foreach (var header in _configuration.Request.Headers)
+            {
+                if (header.Name.ToLower() == "content-type")
+                {
+                    contentType = header.Value;
+                    continue;
+                }
+
+                requestMessage.Headers.Add(header.Name, header.Value);
+            }
+        }
+
+        if (_configuration.Request.Body is not null)
+        {
+            _logger?.LogDebug("Adding body to the mock request");
+
+            if (_configuration.Request.Body is string)
+            {
+                requestMessage.Content = new StringContent(_configuration.Request.Body, Encoding.UTF8, contentType);
+            }
+            else
+            {
+                requestMessage.Content = new StringContent(JsonSerializer.Serialize(_configuration.Request.Body), Encoding.UTF8, "application/json");
+            }
+        }
+
+        return requestMessage;
+    }
+
+    protected virtual async Task OnMockRequest(object sender, EventArgs e)
+    {
+        if (_configuration.Request is null)
+        {
+            _logger?.LogDebug("No mock request is configured. Skipping.");
+            return;
+        }
+
+        using (var httpClient = new HttpClient())
+        {
+            var requestMessage = GetRequestMessage();
+
+            try
+            {
+                _logger?.LogRequest(["Sending mock request"], MessageType.Mocked, _configuration.Request.Method, _configuration.Request.Url);
+
+                await httpClient.SendAsync(requestMessage);
+            }
+            catch (Exception ex)
+            {
+                _logger?.LogError(ex, "An error has occurred while sending the mock request to {url}", _configuration.Request.Url);
+            }
+        }
+    }
+}

--- a/dev-proxy-plugins/Mocks/MockResponsePlugin.cs
+++ b/dev-proxy-plugins/Mocks/MockResponsePlugin.cs
@@ -15,7 +15,7 @@ using Microsoft.DevProxy.Plugins.Behavior;
 using System.Text;
 using Microsoft.Extensions.Logging;
 
-namespace Microsoft.DevProxy.Plugins.MockResponses;
+namespace Microsoft.DevProxy.Plugins.Mocks;
 
 public class MockResponseConfiguration
 {
@@ -35,6 +35,7 @@ public class MockResponseConfiguration
 public class MockResponsePlugin : BaseProxyPlugin
 {
     protected MockResponseConfiguration _configuration = new();
+    protected IProxyContext? _context;
     private MockResponsesLoader? _loader = null;
     private static readonly string _noMocksOptionName = "--no-mocks";
     private static readonly string _mocksFileOptionName = "--mocks-file";
@@ -59,12 +60,14 @@ public class MockResponsePlugin : BaseProxyPlugin
 
         return [_noMocks, _mocksFile];
     }
-    
+
     public override void Register(IPluginEvents pluginEvents,
                             IProxyContext context,
                             ISet<UrlToWatch> urlsToWatch,
                             IConfigurationSection? configSection = null)
     {
+        _context = context;
+
         base.Register(pluginEvents, context, urlsToWatch, configSection);
 
         configSection?.Bind(_configuration);
@@ -79,7 +82,7 @@ public class MockResponsePlugin : BaseProxyPlugin
     private void OnOptionsLoaded(object? sender, OptionsLoadedArgs e)
     {
         InvocationContext context = e.Context;
-        
+
         // allow disabling of mocks as a command line option
         var noMocks = context.ParseResult.GetValueForOption<bool?>(_noMocksOptionName, e.Options);
         if (noMocks.HasValue)
@@ -235,7 +238,8 @@ public class MockResponsePlugin : BaseProxyPlugin
         }
 
         // default the content type to application/json unless set in the mock response
-        if (!headers.Any(h => h.Name.Equals("content-type", StringComparison.OrdinalIgnoreCase)))
+        if (!headers.Any(h => h.Name.Equals("content-type", StringComparison.OrdinalIgnoreCase)) &&
+            matchingResponse.Response?.Body is not null)
         {
             headers.Add(new("content-type", "application/json"));
         }
@@ -260,7 +264,7 @@ public class MockResponsePlugin : BaseProxyPlugin
                 var filePath = Path.Combine(Path.GetDirectoryName(_configuration.MocksFile) ?? "", ProxyUtils.ReplacePathTokens(bodyString.Trim('"').Substring(1)));
                 if (!File.Exists(filePath))
                 {
-                    
+
                     _logger?.LogError("File {filePath} not found. Serving file path in the mock response", filePath);
                     body = bodyString;
                 }
@@ -276,6 +280,15 @@ public class MockResponsePlugin : BaseProxyPlugin
             else
             {
                 body = bodyString;
+            }
+        }
+        else {
+            // we need to remove the content-type header if the body is empty
+            // some clients fail on empty body + content-type
+            var contentTypeHeader = headers.FirstOrDefault(h => h.Name.Equals("content-type", StringComparison.OrdinalIgnoreCase));
+            if (contentTypeHeader is not null)
+            {
+                headers.Remove(contentTypeHeader);
             }
         }
         ProcessMockResponse(ref body, headers, e, matchingResponse);

--- a/dev-proxy-plugins/Mocks/MockResponsesLoader.cs
+++ b/dev-proxy-plugins/Mocks/MockResponsesLoader.cs
@@ -5,7 +5,7 @@ using Microsoft.DevProxy.Abstractions;
 using Microsoft.Extensions.Logging;
 using System.Text.Json;
 
-namespace Microsoft.DevProxy.Plugins.MockResponses;
+namespace Microsoft.DevProxy.Plugins.Mocks;
 
 internal class MockResponsesLoader : IDisposable
 {

--- a/dev-proxy-plugins/RequestLogs/MockGeneratorPlugin.cs
+++ b/dev-proxy-plugins/RequestLogs/MockGeneratorPlugin.cs
@@ -4,7 +4,7 @@
 using System.Text.Json;
 using Microsoft.Extensions.Configuration;
 using Microsoft.DevProxy.Abstractions;
-using Microsoft.DevProxy.Plugins.MockResponses;
+using Microsoft.DevProxy.Plugins.Mocks;
 using Titanium.Web.Proxy.EventArguments;
 using Microsoft.Extensions.Logging;
 

--- a/dev-proxy/ConsoleLogger.cs
+++ b/dev-proxy/ConsoleLogger.cs
@@ -60,6 +60,18 @@ public class ConsoleLogger : IProxyLogger
 
     public void LogRequest(string[] message, MessageType messageType, LoggingContext? context = null)
     {
+        var method = context?.Session.HttpClient.Request.Method;
+        var url = context?.Session.HttpClient.Request.Url;
+        LogRequest(message, messageType, method, url, context);
+    }
+
+    public void LogRequest(string[] message, MessageType messageType, string method, string url)
+    {
+        LogRequest(message, messageType, method, url, null);
+    }
+
+    private void LogRequest(string[] message, MessageType messageType, string? method, string? url, LoggingContext? context = null)
+    {
         var messageLines = new List<string>(message);
 
         // don't log intercepted response to console
@@ -68,9 +80,10 @@ public class ConsoleLogger : IProxyLogger
             // add request context information to the message for messages
             // that are not intercepted requests and have a context
             if (messageType != MessageType.InterceptedRequest &&
-                context is not null)
+                method is not null &&
+                url is not null)
             {
-                messageLines.Add($"{context.Session.HttpClient.Request.Method} {context.Session.HttpClient.Request.Url}");
+                messageLines.Add($"{method} {url}");
             }
 
             lock (ConsoleLock)

--- a/dev-proxy/Program.cs
+++ b/dev-proxy/Program.cs
@@ -13,7 +13,7 @@ if (ProxyHost.LogLevel is not null)
 {
     logger.LogLevel = ProxyHost.LogLevel.Value;
 }
-IProxyContext context = new ProxyContext(logger, ProxyCommandHandler.Configuration);
+IProxyContext context = new ProxyContext(logger, ProxyCommandHandler.Configuration, ProxyEngine.Certificate);
 ProxyHost proxyHost = new();
 
 // this is where the root command is created which contains all commands and subcommands
@@ -85,7 +85,6 @@ foreach (var option in rootCommand.Options)
 // list the remaining incoming options as unknown in the output
 if (incomingOptions.Length > 0)
 {
-
     logger.LogError("Unknown option(s): {unknownOptions}", string.Join(" ", incomingOptions));
     logger.LogInformation("TIP: Use --help view available options");
     logger.LogInformation("TIP: Are you missing a plugin? See: https://aka.ms/devproxy/plugins");

--- a/dev-proxy/ProxyContext.cs
+++ b/dev-proxy/ProxyContext.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.using Microsoft.Extensions.Configuration;
 
+using System.Security.Cryptography.X509Certificates;
 using Microsoft.DevProxy.Abstractions;
 
 namespace Microsoft.DevProxy;
@@ -9,10 +10,12 @@ internal class ProxyContext : IProxyContext
 {
     public IProxyLogger Logger { get; }
     public IProxyConfiguration Configuration { get; }
+    public X509Certificate2? Certificate { get; }
 
-    public ProxyContext(IProxyLogger logger, IProxyConfiguration configuration)
+    public ProxyContext(IProxyLogger logger, IProxyConfiguration configuration, X509Certificate2? certificate)
     {
         Logger = logger ?? throw new ArgumentNullException(nameof(logger));
         Configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+        Certificate = certificate;
     }
 }

--- a/schemas/v0.16.0/mockrequestplugin.schema.json
+++ b/schemas/v0.16.0/mockrequestplugin.schema.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Dev Proxy MockRequestPlugin mocks",
+  "description": "Mock request for the Dev Proxy MockRequestPlugin",
+  "type": "object",
+  "properties": {
+    "$schema": {
+      "type": "string"
+    },
+    "request": {
+      "type": "object",
+      "properties": {
+        "url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "method": {
+          "type": "string",
+          "enum": [
+            "GET",
+            "POST",
+            "PUT",
+            "PATCH",
+            "DELETE",
+            "HEAD",
+            "OPTIONS",
+            "CONNECT",
+            "TRACE"
+          ]
+        },
+        "body": {
+          "type": "object"
+        }
+      },
+      "required": [
+        "url",
+        "method"
+      ]
+    }
+  },
+  "required": [
+    "request"
+  ],
+  "additionalProperties": false
+}


### PR DESCRIPTION
- Adds MockRequestPlugin for issuing web requests using Dev Proxy
- Adds GraphConnectorNotificationPlugin for simulating the Teams Admin Center Graph connector notification
- Renamed the MockResponses namespace to Mocks to accommodate mock requests
- Extends Dev Proxy runtime with a new plugin event for issuing web requests
- Introduces new hotkey (w) for triggering issuing web requests
- Extends Dev Proxy context with the proxy root certificate