### PR TITLE
Updates outdated command output when latest version

### DIFF
--- a/dev-proxy/OutdatedCommandHandler.cs
+++ b/dev-proxy/OutdatedCommandHandler.cs
@@ -7,7 +7,10 @@ public static class OutdatedCommandHandler
     public static async Task CheckVersion(ILogger logger)
     {
         var releaseInfo = await UpdateNotification.CheckForNewVersion(ProxyCommandHandler.Configuration.NewVersionNotification);
-        logger.LogInformation(releaseInfo?.Version);
+        if (releaseInfo != null)
+        {
+            logger.LogInformation(releaseInfo.Version);
+        }
     }
 }
 


### PR DESCRIPTION
Returns no output instead of `[null]`