### PR TITLE
Updates Linux setup scripts. Closes #744

### DIFF
--- a/scripts/setup-beta.ps1
+++ b/scripts/setup-beta.ps1
@@ -35,11 +35,15 @@ Set-Location .\devproxy | Out-Null
 # Get the full path of the current directory
 $full_path = Resolve-Path .
 
-# Get the latest beta Dev Proxy version
-Write-Host "Getting latest beta Dev Proxy version..."
-$response = Invoke-RestMethod -Uri "https://api.github.com/repos/microsoft/dev-proxy/releases?per_page=1" -ErrorAction Stop
-$version = $response[0].tag_name
-Write-Host "Latest beta version is $version"
+if (-not $env:DEV_PROXY_VERSION) {
+    # Get the latest beta Dev Proxy version
+    Write-Host "Getting latest beta Dev Proxy version..."
+    $response = Invoke-RestMethod -Uri "https://api.github.com/repos/microsoft/dev-proxy/releases?per_page=1" -ErrorAction Stop
+    $version = $response[0].tag_name
+    Write-Host "Latest beta version is $version"
+} else {
+    $version = $env:DEV_PROXY_VERSION
+}
 
 # Download Dev Proxy
 Write-Host "Downloading Dev Proxy $version..."

--- a/scripts/setup-beta.sh
+++ b/scripts/setup-beta.sh
@@ -43,9 +43,14 @@ full_path=$(pwd)
 
 set -e # Terminates program immediately if any command below exits with a non-zero exit status
 
-echo "Getting latest beta Dev Proxy version..."
-version=$(curl -s "https://api.github.com/repos/microsoft/dev-proxy/releases?per_page=1" | awk -F: '/"tag_name"/ {print $2}' | sed 's/[", ]//g')
-echo "Latest beta version is $version"
+if [ -z "$0" ]
+then
+    echo "Getting latest beta Dev Proxy version..."
+    version=$(curl -s "https://api.github.com/repos/microsoft/dev-proxy/releases?per_page=1" | awk -F: '/"tag_name"/ {print $2}' | sed 's/[", ]//g')
+    echo "Latest beta version is $version"
+else
+    version=$0
+fi
 
 echo "Downloading Dev Proxy $version..."
 

--- a/scripts/setup.ps1
+++ b/scripts/setup.ps1
@@ -34,11 +34,15 @@ Set-Location .\devproxy | Out-Null
 # Get the full path of the current directory
 $full_path = Resolve-Path .
 
-# Get the latest Dev Proxy version
-Write-Host "Getting latest Dev Proxy version..."
-$response = Invoke-RestMethod -Uri "https://api.github.com/repos/microsoft/dev-proxy/releases/latest" -ErrorAction Stop
-$version = $response.tag_name
-Write-Host "Latest version is $version"
+if (-not $env:DEV_PROXY_VERSION) {
+    # Get the latest Dev Proxy version
+    Write-Host "Getting latest Dev Proxy version..."
+    $response = Invoke-RestMethod -Uri "https://api.github.com/repos/microsoft/dev-proxy/releases/latest" -ErrorAction Stop
+    $version = $response.tag_name
+    Write-Host "Latest version is $version"
+} else {
+    $version = $env:DEV_PROXY_VERSION
+}
 
 # Download Dev Proxy
 Write-Host "Downloading Dev Proxy $version..."

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -42,9 +42,14 @@ full_path=$(pwd)
 
 set -e # Terminates program immediately if any command below exits with a non-zero exit status
 
-echo "Getting latest Dev Proxy version..."
-version=$(curl -s https://api.github.com/repos/microsoft/dev-proxy/releases/latest | awk -F: '/"tag_name"/ {print $2}' | sed 's/[", ]//g')
-echo "Latest version is $version"
+if [ -z "$0" ]
+then
+    echo "Getting latest Dev Proxy version..."
+    version=$(curl -s https://api.github.com/repos/microsoft/dev-proxy/releases/latest | awk -F: '/"tag_name"/ {print $2}' | sed 's/[", ]//g')
+    echo "Latest version is $version"
+else
+    version=$0
+fi
 
 echo "Downloading Dev Proxy $version..."
 


### PR DESCRIPTION
To pass a specific version to the bash script, run:

```bash
bash -c "$(curl -sL https://aka.ms/devproxy/setup.sh)" v0.16.0
```

To pass a version to the PowerShell script, set it as an env var and run the script:

```powershell
$env:DEV_PROXY_VERSION = "v0.16.0"
(Invoke-WebRequest https://aka.ms/devproxy/setup.ps1).Content | Invoke-Expression
```