### PR TITLE
Add new config command to easily open devproxyrc.json

### DIFF
--- a/dev-proxy/Properties/launchSettings.json
+++ b/dev-proxy/Properties/launchSettings.json
@@ -37,6 +37,10 @@
     "Missing arg": {
       "commandName": "Project",
       "commandLineArgs": "--port 8080 --summary-file-path report.md"
+    },
+    "Config": {
+      "commandName": "Project",
+      "commandLineArgs": "config"
     }
   }
 }

--- a/dev-proxy/ProxyHost.cs
+++ b/dev-proxy/ProxyHost.cs
@@ -6,7 +6,6 @@ using Microsoft.Extensions.Logging;
 using System.CommandLine;
 using System.Diagnostics;
 using System.Net;
-using System.Reflection;
 
 namespace Microsoft.DevProxy;
 

--- a/dev-proxy/ProxyHost.cs
+++ b/dev-proxy/ProxyHost.cs
@@ -330,7 +330,7 @@ internal class ProxyHost
         var configCommand = new Command("config", "Open devproxyrc.json");
         configCommand.SetHandler(() =>
         {
-            var cfgPsi = new ProcessStartInfo(Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!, _configFile))
+            var cfgPsi = new ProcessStartInfo(ConfigFile)
             {
                 UseShellExecute = true
             };

--- a/dev-proxy/ProxyHost.cs
+++ b/dev-proxy/ProxyHost.cs
@@ -4,7 +4,9 @@
 using Microsoft.DevProxy.Abstractions;
 using Microsoft.Extensions.Logging;
 using System.CommandLine;
+using System.Diagnostics;
 using System.Net;
+using System.Reflection;
 
 namespace Microsoft.DevProxy;
 
@@ -324,6 +326,17 @@ internal class ProxyHost
         presetCommand.Add(presetGetCommand);
 
         command.Add(presetCommand);
+
+        var configCommand = new Command("config", "Open devproxyrc.json");
+        configCommand.SetHandler(() =>
+        {
+            var cfgPsi = new ProcessStartInfo(Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!, _configFile))
+            {
+                UseShellExecute = true
+            };
+            Process.Start(cfgPsi);
+        });
+        command.Add(configCommand);
 
         var outdatedCommand = new Command("outdated", "Check for new version");
         var outdatedShortOption = new Option<bool>("--short", "Return version only");


### PR DESCRIPTION
I would like to add a new command `config` which automatically opens the `devproxyrc.json` in the default editor.
This would make it a lot easier for new developers to find the file.
The [documentation here](https://learn.microsoft.com/en-us/microsoft-cloud/dev/dev-proxy/get-started?tabs=automated&pivots=client-operating-system-windows#update-the-urls-to-watch) does not mention how to find the file. Instead it only says:
> In the Dev Proxy installation folder, open devproxyrc.json in a text editor.

So with the new command it would be a lot easier, because the documentation can say:
> Run `devproxy config` to open devproxyrc.json in a text editor