### PR TITLE
Unescapes query string params in CRUD API plugin. Closes #823

### DIFF
--- a/dev-proxy-plugins/Mocks/CrudApiPlugin.cs
+++ b/dev-proxy-plugins/Mocks/CrudApiPlugin.cs
@@ -511,7 +511,7 @@ public class CrudApiPlugin : BaseProxyPlugin
                 {
                     continue;
                 }
-                parameters.Add(groupName, match.Groups[groupName].Value);
+                parameters.Add(groupName, Uri.UnescapeDataString(match.Groups[groupName].Value));
             }
             return true;
         });


### PR DESCRIPTION
Unescapes query string params in CRUD API plugin. Closes #823