### PR TITLE
Updates logging from plugins. Closes #887

### DIFF
--- a/dev-proxy-abstractions/ILoggerExtensions.cs
+++ b/dev-proxy-abstractions/ILoggerExtensions.cs
@@ -7,12 +7,12 @@ namespace Microsoft.Extensions.Logging;
 
 public static class ILoggerExtensions
 {
-    public static void LogRequest(this ILogger logger, string[] message, MessageType messageType, LoggingContext? context = null)
+    public static void LogRequest(this ILogger logger, string message, MessageType messageType, LoggingContext? context = null)
     {
         logger.Log(new RequestLog(message, messageType, context));
     }
 
-    public static void LogRequest(this ILogger logger, string[] message, MessageType messageType, string method, string url)
+    public static void LogRequest(this ILogger logger, string message, MessageType messageType, string method, string url)
     {
         logger.Log(new RequestLog(message, messageType, method, url));
     }

--- a/dev-proxy-abstractions/IProxyLogger.cs
+++ b/dev-proxy-abstractions/IProxyLogger.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+
 using Titanium.Web.Proxy.EventArguments;
-using Microsoft.Extensions.Logging;
 
 namespace Microsoft.DevProxy.Abstractions;
 
@@ -16,17 +16,11 @@ public enum MessageType
     Chaos,
     Mocked,
     InterceptedResponse,
-    FinishedProcessingRequest
+    FinishedProcessingRequest,
+    Skipped
 }
 
 public class LoggingContext(SessionEventArgs session)
 {
     public SessionEventArgs Session { get; } = session;
-}
-
-public interface IProxyLogger : ICloneable, ILogger
-{
-    public LogLevel LogLevel { get; set; }
-    public void LogRequest(string[] message, MessageType messageType, LoggingContext? context = null);
-    public void LogRequest(string[] message, MessageType messageType, string method, string url);
 }

--- a/dev-proxy-abstractions/PluginEvents.cs
+++ b/dev-proxy-abstractions/PluginEvents.cs
@@ -99,35 +99,36 @@ public class OptionsLoadedArgs(InvocationContext context, Option[] options)
 
 public class RequestLog
 {
-    public string[] MessageLines { get; set; }
+    public string Message { get; set; }
     public MessageType MessageType { get; set; }
     [JsonIgnore]
     public LoggingContext? Context { get; set; }
     public string? Method { get; init; }
     public string? Url { get; init; }
+    public string? PluginName { get; set; }
 
-    public RequestLog(string[] messageLines, MessageType messageType, LoggingContext? context) :
-        this(messageLines, messageType, context?.Session.HttpClient.Request.Method, context?.Session.HttpClient.Request.Url, context)
+    public RequestLog(string message, MessageType messageType, LoggingContext? context) :
+        this(message, messageType, context?.Session.HttpClient.Request.Method, context?.Session.HttpClient.Request.Url, context)
     {
     }
 
-    public RequestLog(string[] messageLines, MessageType messageType, string method, string url) :
-        this(messageLines, messageType, method, url, context: null)
+    public RequestLog(string message, MessageType messageType, string method, string url) :
+        this(message, messageType, method, url, context: null)
     {
     }
 
-    private RequestLog(string[] messageLines, MessageType messageType, string? method, string? url, LoggingContext? context)
+    private RequestLog(string message, MessageType messageType, string? method, string? url, LoggingContext? context)
     {
-        MessageLines = messageLines ?? throw new ArgumentNullException(nameof(messageLines));
+        Message = message ?? throw new ArgumentNullException(nameof(message));
         MessageType = messageType;
         Context = context;
         Method = method;
         Url = url;
     }
 
-    public void Deconstruct(out string[] message, out MessageType messageType, out LoggingContext? context, out string? method, out string? url)
+    public void Deconstruct(out string message, out MessageType messageType, out LoggingContext? context, out string? method, out string? url)
     {
-        message = MessageLines;
+        message = Message;
         messageType = MessageType;
         context = Context;
         method = Method;

--- a/dev-proxy-plugins/Guidance/GraphBetaSupportGuidancePlugin.cs
+++ b/dev-proxy-plugins/Guidance/GraphBetaSupportGuidancePlugin.cs
@@ -22,17 +22,28 @@ public class GraphBetaSupportGuidancePlugin(IPluginEvents pluginEvents, IProxyCo
     private Task AfterResponseAsync(object? sender, ProxyResponseArgs e)
     {
         Request request = e.Session.HttpClient.Request;
-        if (UrlsToWatch is not null &&
-            e.HasRequestUrlMatch(UrlsToWatch) &&
-            !string.Equals(e.Session.HttpClient.Request.Method, "OPTIONS", StringComparison.OrdinalIgnoreCase) &&
-            ProxyUtils.IsGraphBetaRequest(request))
-            Logger.LogRequest(BuildBetaSupportMessage(), MessageType.Warning, new LoggingContext(e.Session));
+        if (UrlsToWatch is null ||
+            !e.HasRequestUrlMatch(UrlsToWatch))
+        {
+            Logger.LogRequest("URL not matched", MessageType.Skipped, new LoggingContext(e.Session));
+            return Task.CompletedTask;
+        }
+        if (string.Equals(e.Session.HttpClient.Request.Method, "OPTIONS", StringComparison.OrdinalIgnoreCase))
+        {
+            Logger.LogRequest("Skipping OPTIONS request", MessageType.Skipped, new LoggingContext(e.Session));
+            return Task.CompletedTask;
+        }
+        if (!ProxyUtils.IsGraphBetaRequest(request))
+        {
+            Logger.LogRequest("Not a Microsoft Graph beta request", MessageType.Skipped, new LoggingContext(e.Session));
+            return Task.CompletedTask;
+        }
+
+        Logger.LogRequest(BuildBetaSupportMessage(), MessageType.Warning, new LoggingContext(e.Session));
         return Task.CompletedTask;
     }
 
     private static string GetBetaSupportGuidanceUrl() => "https://aka.ms/devproxy/guidance/beta-support";
-    private static string[] BuildBetaSupportMessage()
-    {
-        return [$"Don't use beta APIs in production because they can change or be deprecated.", $"More info at {GetBetaSupportGuidanceUrl()}"];
-    }
+    private static string BuildBetaSupportMessage() =>
+        $"Don't use beta APIs in production because they can change or be deprecated. More info at {GetBetaSupportGuidanceUrl()}";
 }

--- a/dev-proxy-plugins/Inspection/DevToolsPlugin.cs
+++ b/dev-proxy-plugins/Inspection/DevToolsPlugin.cs
@@ -368,7 +368,7 @@ public class DevToolsPlugin(IPluginEvents pluginEvents, IProxyContext context, I
                 Entry = new()
                 {
                     Source = "network",
-                    Text = string.Join(" ", e.RequestLog.MessageLines),
+                    Text = string.Join(" ", e.RequestLog.Message),
                     Level = Entry.GetLevel(e.RequestLog.MessageType),
                     Timestamp = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
                     Url = e.RequestLog.Context?.Session.HttpClient.Request.Url,

--- a/dev-proxy-plugins/MessageUtils.cs
+++ b/dev-proxy-plugins/MessageUtils.cs
@@ -7,13 +7,11 @@ namespace Microsoft.DevProxy.Plugins;
 
 internal class MessageUtils
 {
-    public static string[] BuildUseSdkForErrorsMessage(Request r) => ["To handle API errors more easily, use the Microsoft Graph SDK.", $"More info at {GetMoveToSdkUrl(r)}"];
+    public static string BuildUseSdkForErrorsMessage(Request r) => 
+        $"To handle API errors more easily, use the Microsoft Graph SDK. More info at {GetMoveToSdkUrl(r)}";
 
-    public static string[] BuildUseSdkMessage(Request r) => [
-        "To more easily follow best practices for working with Microsoft Graph, ",
-        "use the Microsoft Graph SDK.",
-        $"More info at {GetMoveToSdkUrl(r)}"
-    ];
+    public static string BuildUseSdkMessage(Request r) =>
+        $"To more easily follow best practices for working with Microsoft Graph, use the Microsoft Graph SDK. More info at {GetMoveToSdkUrl(r)}";
 
     public static string GetMoveToSdkUrl(Request request)
     {

--- a/dev-proxy-plugins/Mocks/GraphMockResponsePlugin.cs
+++ b/dev-proxy-plugins/Mocks/GraphMockResponsePlugin.cs
@@ -20,6 +20,7 @@ public class GraphMockResponsePlugin(IPluginEvents pluginEvents, IProxyContext c
     {
         if (_configuration.NoMocks)
         {
+            Logger.LogRequest("Mocks are disabled", MessageType.Skipped, new LoggingContext(e.Session));
             // mocking has been disabled. Nothing to do
             return;
         }
@@ -71,7 +72,7 @@ public class GraphMockResponsePlugin(IPluginEvents pluginEvents, IProxyContext c
                     }
                 };
 
-                Logger.LogRequest([$"502 {request.Url}"], MessageType.Mocked, new LoggingContext(e.Session));
+                Logger.LogRequest($"502 {request.Url}", MessageType.Mocked, new LoggingContext(e.Session));
             }
             else
             {
@@ -129,7 +130,7 @@ public class GraphMockResponsePlugin(IPluginEvents pluginEvents, IProxyContext c
                     Body = body
                 };
 
-                Logger.LogRequest([$"{mockResponse.Response?.StatusCode ?? 200} {mockResponse.Request?.Url}"], MessageType.Mocked, new LoggingContext(e.Session));
+                Logger.LogRequest($"{mockResponse.Response?.StatusCode ?? 200} {mockResponse.Request?.Url}", MessageType.Mocked, new LoggingContext(e.Session));
             }
 
             responses.Add(response);
@@ -145,7 +146,7 @@ public class GraphMockResponsePlugin(IPluginEvents pluginEvents, IProxyContext c
         var batchResponseString = JsonSerializer.Serialize(batchResponse, ProxyUtils.JsonSerializerOptions);
         ProcessMockResponse(ref batchResponseString, batchHeaders, e, null);
         e.Session.GenericResponse(batchResponseString ?? string.Empty, HttpStatusCode.OK, batchHeaders.Select(h => new HttpHeader(h.Name, h.Value)));
-        Logger.LogRequest([$"200 {e.Session.HttpClient.Request.RequestUri}"], MessageType.Mocked, new LoggingContext(e.Session));
+        Logger.LogRequest($"200 {e.Session.HttpClient.Request.RequestUri}", MessageType.Mocked, new LoggingContext(e.Session));
         e.ResponseState.HasBeenSet = true;
     }
 

--- a/dev-proxy-plugins/Mocks/MockRequestPlugin.cs
+++ b/dev-proxy-plugins/Mocks/MockRequestPlugin.cs
@@ -99,7 +99,7 @@ public class MockRequestPlugin(IPluginEvents pluginEvents, IProxyContext context
 
         try
         {
-            Logger.LogRequest(["Sending mock request"], MessageType.Mocked, _configuration.Request.Method, _configuration.Request.Url);
+            Logger.LogRequest("Sending mock request", MessageType.Mocked, _configuration.Request.Method, _configuration.Request.Url);
 
             await httpClient.SendAsync(requestMessage);
         }

--- a/dev-proxy-plugins/Mocks/OpenAIMockResponsePlugin.cs
+++ b/dev-proxy-plugins/Mocks/OpenAIMockResponsePlugin.cs
@@ -34,18 +34,18 @@ public class OpenAIMockResponsePlugin(IPluginEvents pluginEvents, IProxyContext 
 
     private async Task OnRequestAsync(object sender, ProxyRequestArgs e)
     {
-        using var scope = Logger.BeginScope(Name);
-
         var request = e.Session.HttpClient.Request;
         if (request.Method is null ||
             !request.Method.Equals("POST", StringComparison.OrdinalIgnoreCase) ||
             !request.HasBody)
         {
+            Logger.LogRequest("Request is not a POST request with a body", MessageType.Skipped, new LoggingContext(e.Session));
             return;
         }
 
         if (!TryGetOpenAIRequest(request.BodyString, out var openAiRequest))
         {
+            Logger.LogRequest("Skipping non-OpenAI request", MessageType.Skipped, new LoggingContext(e.Session));
             return;
         }
 
@@ -137,7 +137,7 @@ public class OpenAIMockResponsePlugin(IPluginEvents pluginEvents, IProxyContext 
             ]
         );
         e.ResponseState.HasBeenSet = true;
-        Logger.LogRequest([$"200 {localLmUrl}"], MessageType.Mocked, new LoggingContext(e.Session));
+        Logger.LogRequest($"200 {localLmUrl}", MessageType.Mocked, new LoggingContext(e.Session));
     }
 }
 

--- a/dev-proxy-plugins/OpenApi/OpenApiDocumentExtensions.cs
+++ b/dev-proxy-plugins/OpenApi/OpenApiDocumentExtensions.cs
@@ -130,7 +130,7 @@ public static class OpenApiDocumentExtensions
         foreach (var request in requests)
         {
             // get scopes from the token
-            var methodAndUrl = request.MessageLines.First();
+            var methodAndUrl = request.Message;
             var methodAndUrlChunks = methodAndUrl.Split(' ');
             logger.LogDebug("Checking request {request}...", methodAndUrl);
             var (method, url) = (methodAndUrlChunks[0].ToUpper(), methodAndUrlChunks[1]);

--- a/dev-proxy-plugins/RandomErrors/LatencyPlugin.cs
+++ b/dev-proxy-plugins/RandomErrors/LatencyPlugin.cs
@@ -30,12 +30,15 @@ public class LatencyPlugin(IPluginEvents pluginEvents, IProxyContext context, IL
 
     private async Task OnRequestAsync(object? sender, ProxyRequestArgs e)
     {
-        if (UrlsToWatch is not null
-            && e.ShouldExecute(UrlsToWatch))
+        if (UrlsToWatch is null ||
+            !e.ShouldExecute(UrlsToWatch))
         {
-            var delay = _random.Next(_configuration.MinMs, _configuration.MaxMs);
-            Logger.LogRequest([$"Delaying request for {delay}ms"], MessageType.Chaos, new LoggingContext(e.Session));
-            await Task.Delay(delay);
+            Logger.LogRequest("URL not matched", MessageType.Skipped, new LoggingContext(e.Session));
+            return;
         }
+
+        var delay = _random.Next(_configuration.MinMs, _configuration.MaxMs);
+        Logger.LogRequest($"Delaying request for {delay}ms", MessageType.Chaos, new LoggingContext(e.Session));
+        await Task.Delay(delay);
     }
 }

--- a/dev-proxy-plugins/RequestLogs/ApiCenterMinimalPermissionsPlugin.cs
+++ b/dev-proxy-plugins/RequestLogs/ApiCenterMinimalPermissionsPlugin.cs
@@ -92,7 +92,7 @@ public class ApiCenterMinimalPermissionsPlugin(IPluginEvents pluginEvents, IProx
         var interceptedRequests = e.RequestLogs
             .Where(l =>
                 l.MessageType == MessageType.InterceptedRequest &&
-                !l.MessageLines.First().StartsWith("OPTIONS") &&
+                !l.Message.StartsWith("OPTIONS") &&
                 l.Context?.Session is not null &&
                 l.Context.Session.HttpClient.Request.Headers.Any(h => h.Name.Equals("authorization", StringComparison.OrdinalIgnoreCase))
             );
@@ -122,7 +122,7 @@ public class ApiCenterMinimalPermissionsPlugin(IPluginEvents pluginEvents, IProx
         var errors = new List<ApiPermissionError>();
         var results = new List<ApiCenterMinimalPermissionsPluginReportApiResult>();
         var unmatchedRequests = new List<string>(
-            unmatchedApicRequests.Select(r => r.MessageLines.First())
+            unmatchedApicRequests.Select(r => r.Message)
         );
         
         foreach (var (apiDefinition, requests) in requestsByApiDefinition)
@@ -214,7 +214,7 @@ public class ApiCenterMinimalPermissionsPlugin(IPluginEvents pluginEvents, IProx
         var requestsByApiDefinition = new Dictionary<ApiDefinition, List<RequestLog>>();
         foreach (var request in interceptedRequests)
         {
-            var url = request.MessageLines.First().Split(' ')[1];
+            var url = request.Message.Split(' ')[1];
             Logger.LogDebug("Matching request {requestUrl} to API definitions...", url);
 
             var matchingKey = apiDefinitionsByUrl.Keys.FirstOrDefault(url.StartsWith);

--- a/dev-proxy-plugins/RequestLogs/ApiCenterOnboardingPlugin.cs
+++ b/dev-proxy-plugins/RequestLogs/ApiCenterOnboardingPlugin.cs
@@ -114,7 +114,7 @@ public class ApiCenterOnboardingPlugin(IPluginEvents pluginEvents, IProxyContext
             .Where(l => l.MessageType == MessageType.InterceptedRequest)
             .Select(request =>
             {
-                var methodAndUrl = request.MessageLines.First().Split(' ');
+                var methodAndUrl = request.Message.Split(' ');
                 return (method: methodAndUrl[0], url: methodAndUrl[1]);
             })
             .Where(r => !r.method.Equals("OPTIONS", StringComparison.OrdinalIgnoreCase))

--- a/dev-proxy-plugins/RequestLogs/ApiCenterProductionVersionPlugin.cs
+++ b/dev-proxy-plugins/RequestLogs/ApiCenterProductionVersionPlugin.cs
@@ -164,7 +164,7 @@ public class ApiCenterProductionVersionPlugin(IPluginEvents pluginEvents, IProxy
 
         foreach (var request in interceptedRequests)
         {
-            var methodAndUrlString = request.MessageLines.First();
+            var methodAndUrlString = request.Message;
             var methodAndUrl = methodAndUrlString.Split(' ');
             var (method, url) = (methodAndUrl[0], methodAndUrl[1]);
             if (method == "OPTIONS")

--- a/dev-proxy-plugins/RequestLogs/ExecutionSummaryPlugin.cs
+++ b/dev-proxy-plugins/RequestLogs/ExecutionSummaryPlugin.cs
@@ -215,7 +215,7 @@ public class ExecutionSummaryPlugin(IPluginEvents pluginEvents, IProxyContext co
 
     private static string GetRequestMessage(RequestLog requestLog)
     {
-        return string.Join(' ', requestLog.MessageLines);
+        return string.Join(' ', requestLog.Message);
     }
 
     private static string GetMethodAndUrl(RequestLog requestLog)

--- a/dev-proxy-plugins/RequestLogs/GraphMinimalPermissionsGuidancePlugin.cs
+++ b/dev-proxy-plugins/RequestLogs/GraphMinimalPermissionsGuidancePlugin.cs
@@ -87,7 +87,7 @@ public class GraphMinimalPermissionsGuidancePlugin(IPluginEvents pluginEvents, I
                 continue;
             }
 
-            var methodAndUrlString = request.MessageLines.First();
+            var methodAndUrlString = request.Message;
             var methodAndUrl = GetMethodAndUrl(methodAndUrlString);
             if (methodAndUrl.method.Equals("OPTIONS", StringComparison.OrdinalIgnoreCase))
             {

--- a/dev-proxy-plugins/RequestLogs/GraphMinimalPermissionsPlugin.cs
+++ b/dev-proxy-plugins/RequestLogs/GraphMinimalPermissionsPlugin.cs
@@ -56,7 +56,7 @@ public class GraphMinimalPermissionsPlugin(IPluginEvents pluginEvents, IProxyCon
                 continue;
             }
 
-            var methodAndUrlString = request.MessageLines.First();
+            var methodAndUrlString = request.Message;
             var methodAndUrl = GetMethodAndUrl(methodAndUrlString);
             if (methodAndUrl.method.Equals("OPTIONS", StringComparison.OrdinalIgnoreCase))
             {

--- a/dev-proxy-plugins/RequestLogs/HttpFileGeneratorPlugin.cs
+++ b/dev-proxy-plugins/RequestLogs/HttpFileGeneratorPlugin.cs
@@ -149,7 +149,7 @@ public class HttpFileGeneratorPlugin(IPluginEvents pluginEvents, IProxyContext c
                 continue;
             }
 
-            var methodAndUrlString = request.MessageLines.First();
+            var methodAndUrlString = request.Message;
             Logger.LogDebug("Adding request {methodAndUrl}...", methodAndUrlString);
 
             var methodAndUrl = methodAndUrlString.Split(' ');

--- a/dev-proxy-plugins/RequestLogs/MinimalPermissionsPlugin.cs
+++ b/dev-proxy-plugins/RequestLogs/MinimalPermissionsPlugin.cs
@@ -63,7 +63,7 @@ public class MinimalPermissionsPlugin(IPluginEvents pluginEvents, IProxyContext 
         var interceptedRequests = e.RequestLogs
             .Where(l =>
                 l.MessageType == MessageType.InterceptedRequest &&
-                !l.MessageLines.First().StartsWith("OPTIONS") &&
+                !l.Message.StartsWith("OPTIONS") &&
                 l.Context?.Session is not null &&
                 l.Context.Session.HttpClient.Request.Headers.Any(h => h.Name.Equals("authorization", StringComparison.OrdinalIgnoreCase))
             );
@@ -87,7 +87,7 @@ public class MinimalPermissionsPlugin(IPluginEvents pluginEvents, IProxyContext 
         var errors = new List<ApiPermissionError>();
         var results = new List<MinimalPermissionsPluginReportApiResult>();
         var unmatchedRequests = new List<string>(
-            unmatchedApiSpecRequests.Select(r => r.MessageLines.First())
+            unmatchedApiSpecRequests.Select(r => r.Message)
         );
 
         foreach (var (apiSpec, requests) in requestsByApiSpec)
@@ -214,7 +214,7 @@ public class MinimalPermissionsPlugin(IPluginEvents pluginEvents, IProxyContext 
         var requestsByApiSpec = new Dictionary<OpenApiDocument, List<RequestLog>>();
         foreach (var request in interceptedRequests)
         {
-            var url = request.MessageLines.First().Split(' ')[1];
+            var url = request.Message.Split(' ')[1];
             Logger.LogDebug("Matching request {requestUrl} to API specs...", url);
 
             var matchingKey = apiSpecsByUrl.Keys.FirstOrDefault(url.StartsWith);

--- a/dev-proxy-plugins/RequestLogs/MockGeneratorPlugin.cs
+++ b/dev-proxy-plugins/RequestLogs/MockGeneratorPlugin.cs
@@ -43,7 +43,7 @@ public class MockGeneratorPlugin(IPluginEvents pluginEvents, IProxyContext conte
                 continue;
             }
 
-            var methodAndUrlString = request.MessageLines.First();
+            var methodAndUrlString = request.Message;
             Logger.LogDebug("Processing request {methodAndUrlString}...", methodAndUrlString);
 
             var (method, url) = GetMethodAndUrl(methodAndUrlString);

--- a/dev-proxy-plugins/RequestLogs/OpenApiSpecGeneratorPlugin.cs
+++ b/dev-proxy-plugins/RequestLogs/OpenApiSpecGeneratorPlugin.cs
@@ -323,7 +323,7 @@ public class OpenApiSpecGeneratorPlugin(IPluginEvents pluginEvents, IProxyContex
                 continue;
             }
 
-            var methodAndUrlString = request.MessageLines.First();
+            var methodAndUrlString = request.Message.First();
             Logger.LogDebug("Processing request {methodAndUrlString}...", methodAndUrlString);
 
             try

--- a/dev-proxy/Logging/ProxyConsoleFormatterOptions.cs
+++ b/dev-proxy/Logging/ProxyConsoleFormatterOptions.cs
@@ -1,0 +1,11 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.Extensions.Logging.Console;
+
+namespace Microsoft.DevProxy.Logging;
+
+public class ProxyConsoleFormatterOptions: ConsoleFormatterOptions
+{
+    public bool ShowSkipMessages { get; set; } = true;
+}

--- a/dev-proxy/ProxyConfiguration.cs
+++ b/dev-proxy/ProxyConfiguration.cs
@@ -37,4 +37,5 @@ public class ProxyConfiguration : IProxyConfiguration
     public LanguageModelConfiguration? LanguageModel { get; set; }
     public MockRequestHeader[]? FilterByHeaders { get; set; }
     public int ApiPort { get; set; } = 8897;
+    public bool ShowSkipMessages { get; set; } = true;
 }

--- a/dev-proxy/ProxyEngine.cs
+++ b/dev-proxy/ProxyEngine.cs
@@ -467,7 +467,7 @@ public class ProxyEngine(IProxyConfiguration config, ISet<UrlToWatch> urlsToWatc
             using var scope = _logger.BeginScope(e.HttpClient.Request.Method ?? "", e.HttpClient.Request.Url, e.GetHashCode());
 
             e.UserData = e.HttpClient.Request;
-            _logger.LogRequest([$"{e.HttpClient.Request.Method} {e.HttpClient.Request.Url}"], MessageType.InterceptedRequest, new LoggingContext(e));
+            _logger.LogRequest($"{e.HttpClient.Request.Method} {e.HttpClient.Request.Url}", MessageType.InterceptedRequest, new LoggingContext(e));
             await HandleRequestAsync(e, proxyRequestArgs);
         }
     }
@@ -479,7 +479,7 @@ public class ProxyEngine(IProxyConfiguration config, ISet<UrlToWatch> urlsToWatc
         // We only need to set the proxy header if the proxy has not set a response and the request is going to be sent to the target.
         if (!proxyRequestArgs.ResponseState.HasBeenSet)
         {
-            _logger?.LogRequest(["Passed through"], MessageType.PassedThrough, new LoggingContext(e));
+            _logger?.LogRequest("Passed through", MessageType.PassedThrough, new LoggingContext(e));
             AddProxyHeader(e.HttpClient.Request);
         }
     }
@@ -578,9 +578,9 @@ public class ProxyEngine(IProxyConfiguration config, ISet<UrlToWatch> urlsToWatc
             using var scope = _logger.BeginScope(e.HttpClient.Request.Method ?? "", e.HttpClient.Request.Url, e.GetHashCode());
 
             var message = $"{e.HttpClient.Request.Method} {e.HttpClient.Request.Url}";
-            _logger.LogRequest([message], MessageType.InterceptedResponse, new LoggingContext(e));
+            _logger.LogRequest(message, MessageType.InterceptedResponse, new LoggingContext(e));
             await _pluginEvents.RaiseProxyAfterResponseAsync(proxyResponseArgs, ExceptionHandler);
-            _logger.LogRequest([message], MessageType.FinishedProcessingRequest, new LoggingContext(e));
+            _logger.LogRequest(message, MessageType.FinishedProcessingRequest, new LoggingContext(e));
 
             // clean up
             _pluginData.Remove(e.GetHashCode());

--- a/dev-proxy/devproxyrc.json
+++ b/dev-proxy/devproxyrc.json
@@ -21,5 +21,6 @@
   },
   "rate": 50,
   "logLevel": "information",
-  "newVersionNotification": "stable"
+  "newVersionNotification": "stable",
+  "showSkipMessages": true
 }


### PR DESCRIPTION
Updates logging from plugins. Closes #887

Introduces new `skip` messages to help understand plugin execution. Skip messages are enabled by default and can be disabled using the new `showSkipMessages` setting in devproxyrc.json.

This PR also introduces a breaking change, where we change the shape of a log message from `string[]` to `string`. This makes it easier to understand how plugins process a request, because each plugin logs a single message.