### PR TITLE
Added SigningKey parameter to JWT Token generator (fixes #913)

### DIFF
--- a/dev-proxy/ApiControllers/ProxyController.cs
+++ b/dev-proxy/ApiControllers/ProxyController.cs
@@ -55,6 +55,11 @@ public class ProxyController(IProxyState proxyState) : ControllerBase
     [HttpPost("createJwtToken")]
     public IActionResult CreateJwtToken([FromBody] JwtOptions jwtOptions)
     {
+        if (jwtOptions.SigningKey != null && jwtOptions.SigningKey.Length < 32)
+        {
+            return BadRequest("The specified signing key is too short. A signing key must be at least 32 characters.");
+        }
+
         var token = JwtTokenGenerator.CreateToken(jwtOptions);
 
         return Ok(new JwtInfo { Token = token });

--- a/dev-proxy/CommandHandlers/JwtBinder.cs
+++ b/dev-proxy/CommandHandlers/JwtBinder.cs
@@ -6,8 +6,8 @@ using System.CommandLine;
 using System.CommandLine.Binding;
 
 namespace Microsoft.DevProxy.CommandHandlers
-{    
-    public class JwtBinder(Option<string> nameOption, Option<IEnumerable<string>> audiencesOption, Option<string> issuerOption, Option<IEnumerable<string>> rolesOption, Option<IEnumerable<string>> scopesOption, Option<Dictionary<string, string>> claimsOption, Option<double> validForOption,Option<string> signingKeyOption) : BinderBase<JwtOptions>
+{
+    public class JwtBinder(Option<string> nameOption, Option<IEnumerable<string>> audiencesOption, Option<string> issuerOption, Option<IEnumerable<string>> rolesOption, Option<IEnumerable<string>> scopesOption, Option<Dictionary<string, string>> claimsOption, Option<double> validForOption, Option<string> signingKeyOption) : BinderBase<JwtOptions>
     {
         private readonly Option<string> _nameOption = nameOption;
         private readonly Option<IEnumerable<string>> _audiencesOption = audiencesOption;
@@ -17,7 +17,7 @@ namespace Microsoft.DevProxy.CommandHandlers
         private readonly Option<Dictionary<string, string>> _claimsOption = claimsOption;
         private readonly Option<double> _validForOption = validForOption;
         private readonly Option<string> _signingKeyOption = signingKeyOption;
-        
+
         protected override JwtOptions GetBoundValue(BindingContext bindingContext)
         {
             return new JwtOptions

--- a/dev-proxy/CommandHandlers/JwtBinder.cs
+++ b/dev-proxy/CommandHandlers/JwtBinder.cs
@@ -7,7 +7,7 @@ using System.CommandLine.Binding;
 
 namespace Microsoft.DevProxy.CommandHandlers
 {    
-    public class JwtBinder(Option<string> nameOption, Option<IEnumerable<string>> audiencesOption, Option<string> issuerOption, Option<IEnumerable<string>> rolesOption, Option<IEnumerable<string>> scopesOption, Option<Dictionary<string, string>> claimsOption, Option<double> validForOption) : BinderBase<JwtOptions>
+    public class JwtBinder(Option<string> nameOption, Option<IEnumerable<string>> audiencesOption, Option<string> issuerOption, Option<IEnumerable<string>> rolesOption, Option<IEnumerable<string>> scopesOption, Option<Dictionary<string, string>> claimsOption, Option<double> validForOption,Option<string> signingKeyOption) : BinderBase<JwtOptions>
     {
         private readonly Option<string> _nameOption = nameOption;
         private readonly Option<IEnumerable<string>> _audiencesOption = audiencesOption;
@@ -16,7 +16,8 @@ namespace Microsoft.DevProxy.CommandHandlers
         private readonly Option<IEnumerable<string>> _scopesOption = scopesOption;
         private readonly Option<Dictionary<string, string>> _claimsOption = claimsOption;
         private readonly Option<double> _validForOption = validForOption;
-
+        private readonly Option<string> _signingKeyOption = signingKeyOption;
+        
         protected override JwtOptions GetBoundValue(BindingContext bindingContext)
         {
             return new JwtOptions
@@ -27,7 +28,8 @@ namespace Microsoft.DevProxy.CommandHandlers
                 Roles = bindingContext.ParseResult.GetValueForOption(_rolesOption),
                 Scopes = bindingContext.ParseResult.GetValueForOption(_scopesOption),
                 Claims = bindingContext.ParseResult.GetValueForOption(_claimsOption),
-                ValidFor = bindingContext.ParseResult.GetValueForOption(_validForOption)
+                ValidFor = bindingContext.ParseResult.GetValueForOption(_validForOption),
+                SigningKey = bindingContext.ParseResult.GetValueForOption(_signingKeyOption)
             };
         }
     }

--- a/dev-proxy/Jwt/JwtCreatorOptions.cs
+++ b/dev-proxy/Jwt/JwtCreatorOptions.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Security.Cryptography;
+
 namespace Microsoft.DevProxy.Jwt;
 
 internal sealed record JwtCreatorOptions
@@ -14,6 +16,7 @@ internal sealed record JwtCreatorOptions
     public required IEnumerable<string> Roles { get; init; }
     public required IEnumerable<string> Scopes { get; init; }
     public required Dictionary<string, string> Claims { get; init; }
+    public required string SigningKey { get; init; }
 
     public static JwtCreatorOptions Create(JwtOptions options)
     {
@@ -27,7 +30,8 @@ internal sealed record JwtCreatorOptions
             Scopes = options.Scopes ?? [],
             Claims = options.Claims ?? [],
             NotBefore = DateTime.UtcNow,
-            ExpiresOn = DateTime.UtcNow.AddMinutes(options.ValidFor ?? 60)
+            ExpiresOn = DateTime.UtcNow.AddMinutes(options.ValidFor ?? 60),
+            SigningKey = options.SigningKey ?? RandomNumberGenerator.GetHexString(32)
         };
     }
 }

--- a/dev-proxy/Jwt/JwtCreatorOptions.cs
+++ b/dev-proxy/Jwt/JwtCreatorOptions.cs
@@ -31,7 +31,7 @@ internal sealed record JwtCreatorOptions
             Claims = options.Claims ?? [],
             NotBefore = DateTime.UtcNow,
             ExpiresOn = DateTime.UtcNow.AddMinutes(options.ValidFor ?? 60),
-            SigningKey = options.SigningKey ?? RandomNumberGenerator.GetHexString(32)
+            SigningKey = (string.IsNullOrEmpty(options.SigningKey) ? RandomNumberGenerator.GetHexString(32) : options.SigningKey)
         };
     }
 }

--- a/dev-proxy/Jwt/JwtOptions.cs
+++ b/dev-proxy/Jwt/JwtOptions.cs
@@ -12,4 +12,5 @@ public class JwtOptions
     public IEnumerable<string>? Scopes { get; set; }
     public Dictionary<string, string>? Claims { get; set; }
     public double? ValidFor { get; set; }
+    public string? SigningKey { get; set; }
 }

--- a/dev-proxy/Jwt/JwtTokenGenerator.cs
+++ b/dev-proxy/Jwt/JwtTokenGenerator.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 using System.IdentityModel.Tokens.Jwt;
-using System.Security.Cryptography;
+using System.Text;
 
 namespace Microsoft.DevProxy.Jwt;
 
@@ -14,7 +14,7 @@ internal static class JwtTokenGenerator
 
         var jwtIssuer = new JwtIssuer(
             options.Issuer,
-            RandomNumberGenerator.GetBytes(32)
+            Encoding.UTF8.GetBytes(options.SigningKey)
         );
 
         var jwtToken = jwtIssuer.CreateSecurityToken(options);

--- a/dev-proxy/ProxyHost.cs
+++ b/dev-proxy/ProxyHost.cs
@@ -417,7 +417,7 @@ internal class ProxyHost
         jwtValidForOption.AddAlias("-v");
         jwtCreateCommand.AddOption(jwtValidForOption);
 
-        var jwtSigningKeyOption = new Option<string>("--signingkey", "The signing key to sign the token. Minimum length is 32 characters.");
+        var jwtSigningKeyOption = new Option<string>("--signing-key", "The signing key to sign the token. Minimum length is 32 characters.");
         jwtSigningKeyOption.AddAlias("-k");
         jwtSigningKeyOption.AddValidator(input =>
         {

--- a/dev-proxy/ProxyHost.cs
+++ b/dev-proxy/ProxyHost.cs
@@ -382,14 +382,15 @@ internal class ProxyHost
 
         var jwtClaimsOption = new Option<Dictionary<string, string>>("--claims",
             description: "Claims to add to the token. Specify once for each claim in the format \"name:value\".",
-            parseArgument: result => {
+            parseArgument: result =>
+            {
                 var claims = new Dictionary<string, string>();
                 foreach (var token in result.Tokens)
                 {
                     var claim = token.Value.Split(":");
 
                     if (claim.Length != 2)
-                    {   
+                    {
                         result.ErrorMessage = $"Invalid claim format: '{token.Value}'. Expected format is name:value.";
                         return claims ?? [];
                     }
@@ -416,7 +417,26 @@ internal class ProxyHost
         jwtValidForOption.AddAlias("-v");
         jwtCreateCommand.AddOption(jwtValidForOption);
 
-        jwtCreateCommand.SetHandler( 
+        var jwtSigningKeyOption = new Option<string>("--signingkey", "The signing key to sign the token. Minimum length is 32 characters.");
+        jwtSigningKeyOption.AddAlias("-k");
+        jwtSigningKeyOption.AddValidator(input =>
+        {
+            try
+            {
+                var value = input.GetValueForOption(jwtSigningKeyOption);
+                if (string.IsNullOrWhiteSpace(value) || value.Length < 32)
+                {
+                    input.ErrorMessage = $"Requires option '--{jwtSigningKeyOption.Name}' to be at least 32 characters";
+                }
+            }
+            catch (InvalidOperationException ex)
+            {
+                input.ErrorMessage = ex.Message;
+            }
+        });
+        jwtCreateCommand.AddOption(jwtSigningKeyOption);
+
+        jwtCreateCommand.SetHandler(
             JwtCommandHandler.GetToken,
             new JwtBinder(
                 jwtNameOption,
@@ -425,7 +445,8 @@ internal class ProxyHost
                 jwtRolesOption,
                 jwtScopesOption,
                 jwtClaimsOption,
-                jwtValidForOption
+                jwtValidForOption,
+                jwtSigningKeyOption
             )
         );
         jwtCommand.Add(jwtCreateCommand);


### PR DESCRIPTION
The JWT Token generated by dev-proxy cannot be validated into an ASP.NET Core Web API.
Adding the signing key is possibile to validate the generated JWT token for a specific user and scope for a endpoint that requires authentication and authorization