### PR TITLE
Allows mocking responses with multiple headers with the same name. Fixes #927

### DIFF
--- a/dev-proxy-abstractions/ProxyUtils.cs
+++ b/dev-proxy-abstractions/ProxyUtils.cs
@@ -339,7 +339,11 @@ public static class ProxyUtils
                     continue;
                 }
 
-                allHeaders.Remove(existingHeader);
+                // don't remove headers that we've just added
+                if (!headersToAdd.Contains(existingHeader))
+                {
+                    allHeaders.Remove(existingHeader);
+                }
             }
 
             allHeaders.Add(header);


### PR DESCRIPTION
Allows mocking responses with multiple headers with the same name. Fixes #927